### PR TITLE
When I fixed the logs, I broke the tests

### DIFF
--- a/migration_steps/transform_casrec/tests/transformations/conftest.py
+++ b/migration_steps/transform_casrec/tests/transformations/conftest.py
@@ -1,10 +1,14 @@
+import logging
+
 import pytest
 
-from custom_logger import custom_logger
+import custom_logger
 from utilities import transformations_from_mapping
 import pandas as pd
 
-logger = custom_logger(name="transformation_test")
+logger = logging.getLogger("tests")
+logger.addHandler(custom_logger.MyHandler())
+logger.setLevel("INFO")
 
 
 @pytest.fixture()

--- a/migration_steps/transform_casrec/tests/transformations/transformations_from_mapping/test_perform_transformations.py
+++ b/migration_steps/transform_casrec/tests/transformations/transformations_from_mapping/test_perform_transformations.py
@@ -11,8 +11,8 @@ from utilities.transformations_from_mapping import (
 from pytest_cases import parametrize_with_cases
 
 test_source_data_dict = {
-    "Remarks": ["row1", "row2", "row3"],
-    "Logdate": ["blah", "blah", "blah"],
+    "Remarks": ["row1", "row2", "row3", "row4", "row5"],
+    "Logdate": ["blah", "blah", "blah", "blah", "blah"],
 }
 
 test_source_data_df = pd.DataFrame(


### PR DESCRIPTION
## Purpose

Made the tests use the same logger as everything else, so they work again
Also changed the test data to have 5 items so I don't have to mock the config (sometimes we take a random sample of data and the number of records is set in the config, default 5, the test only had 3 rows so it failed when it really shouldn't have)

Logger changes merged
Tests broke, sadness happened, oops
This is now sorted
