### PR TITLE
IN-544 datatypes in transform step

### DIFF
--- a/migration_steps/shared/decorators.py
+++ b/migration_steps/shared/decorators.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import sys
 import time
 
+
 log = logging.getLogger("root")
 environment = os.environ.get("ENVIRONMENT")
 
@@ -13,11 +14,12 @@ environment = os.environ.get("ENVIRONMENT")
 def timer(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
+
         t = time.process_time()
 
         function_path = Path(sys.modules[func.__module__].__file__).parts
-        transformation_step = function_path[function_path.index("migration_steps") + 1]
         function_name = func.__name__
+        filename = function_path[-1]
 
         try:
             return func(*args, **kwargs)
@@ -26,9 +28,8 @@ def timer(func):
             time_to_run = round(time.process_time() - t, 2)
 
             log.debug(
-                f"Function '{function_name}' in step "
-                f"'{transformation_step}' ran in "
-                f"{time_to_run} secs"
+                f"Function '{function_name}' from '{filename}' ran in "
+                f"{time_to_run} secs "
             )
 
     return wrapper

--- a/migration_steps/shared/decorators.py
+++ b/migration_steps/shared/decorators.py
@@ -1,0 +1,34 @@
+import functools
+import logging
+import os
+from pathlib import Path
+
+import sys
+import time
+
+log = logging.getLogger("root")
+environment = os.environ.get("ENVIRONMENT")
+
+
+def timer(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        t = time.process_time()
+
+        function_path = Path(sys.modules[func.__module__].__file__).parts
+        transformation_step = function_path[function_path.index("migration_steps") + 1]
+        function_name = func.__name__
+
+        try:
+            return func(*args, **kwargs)
+
+        finally:
+            time_to_run = round(time.process_time() - t, 2)
+
+            log.debug(
+                f"Function '{function_name}' in step "
+                f"'{transformation_step}' ran in "
+                f"{time_to_run} secs"
+            )
+
+    return wrapper

--- a/migration_steps/transform_casrec/app/entities/clients/persons.py
+++ b/migration_steps/transform_casrec/app/entities/clients/persons.py
@@ -20,6 +20,15 @@ def insert_persons_clients(config, etl2_db):
         file_name=mapping_def_filename, stage_name="transform_casrec"
     )
 
+    # sirius_details = get_mapping_dict(
+    #     file_name=mapping_def_filename,
+    #     stage_name="sirius_details",
+    #     only_complete_fields=False,
+    # )
+    #
+    # date_fields = [k for k, v in sirius_details.items() if v['data_type'] in ['date',
+    #                                                                          'datetime']]
+
     source_data_query = generate_select_string_from_mapping(
         mapping=mapping_dict,
         source_table_name=definition["source_table_name"],

--- a/migration_steps/transform_casrec/app/entities/clients/persons.py
+++ b/migration_steps/transform_casrec/app/entities/clients/persons.py
@@ -11,23 +11,20 @@ definition = {
     "destination_table_name": "persons",
 }
 
-mapping_def_filename = "client_persons_mapping"
+mapping_file_name = "client_persons_mapping"
 
 
 def insert_persons_clients(config, etl2_db):
 
     mapping_dict = get_mapping_dict(
-        file_name=mapping_def_filename, stage_name="transform_casrec"
+        file_name=mapping_file_name, stage_name="transform_casrec"
     )
 
-    # sirius_details = get_mapping_dict(
-    #     file_name=mapping_def_filename,
-    #     stage_name="sirius_details",
-    #     only_complete_fields=False,
-    # )
-    #
-    # date_fields = [k for k, v in sirius_details.items() if v['data_type'] in ['date',
-    #                                                                          'datetime']]
+    sirius_details = get_mapping_dict(
+        file_name=mapping_file_name,
+        stage_name="sirius_details",
+        only_complete_fields=False,
+    )
 
     source_data_query = generate_select_string_from_mapping(
         mapping=mapping_dict,
@@ -46,6 +43,11 @@ def insert_persons_clients(config, etl2_db):
         source_data_df,
         config.connection_string,
         config.etl2_schema,
+        sirius_details,
     )
 
-    etl2_db.insert_data(table_name=definition["destination_table_name"], df=persons_df)
+    etl2_db.insert_data(
+        table_name=definition["destination_table_name"],
+        df=persons_df,
+        sirius_details=sirius_details,
+    )

--- a/migration_steps/transform_casrec/app/transform_data/apply_datatypes.py
+++ b/migration_steps/transform_casrec/app/transform_data/apply_datatypes.py
@@ -28,9 +28,8 @@ def apply_datatypes(mapping_details: Dict, df: pd.DataFrame) -> pd.DataFrame:
 
     log.log(config.VERBOSE, f"cols_with_datatype: {cols_with_datatype}")
 
-    result_df = df
-    # result_df = df.astype({k: v for k, v in cols_with_datatype.items()})
-    # result_df = result_df.replace({'NaT': None})
+    result_df = df.astype({k: v for k, v in cols_with_datatype.items()})
+    log.log(config.VERBOSE, f"table info: {result_df.info()}")
 
     log.log(
         config.DATA,

--- a/migration_steps/transform_casrec/app/transform_data/apply_datatypes.py
+++ b/migration_steps/transform_casrec/app/transform_data/apply_datatypes.py
@@ -29,7 +29,6 @@ def apply_datatypes(mapping_details: Dict, df: pd.DataFrame) -> pd.DataFrame:
     log.log(config.VERBOSE, f"cols_with_datatype: {cols_with_datatype}")
 
     result_df = df.astype({k: v for k, v in cols_with_datatype.items()})
-    log.log(config.VERBOSE, f"table info: {result_df.info()}")
 
     log.log(
         config.DATA,

--- a/migration_steps/transform_casrec/app/transform_data/apply_datatypes.py
+++ b/migration_steps/transform_casrec/app/transform_data/apply_datatypes.py
@@ -1,0 +1,40 @@
+import logging
+import os
+from typing import Dict
+
+import helpers
+import pandas as pd
+
+log = logging.getLogger("root")
+environment = os.environ.get("ENVIRONMENT")
+
+config = helpers.get_config(env=environment)
+
+datatype_remap = {"date": "datetime64", "datetime": "datetime64", "dict": "str"}
+
+
+def apply_datatypes(mapping_details: Dict, df: pd.DataFrame) -> pd.DataFrame:
+
+    log.log(config.VERBOSE, "starting to apply column datatypes")
+    log.log(config.VERBOSE, f"datatypes mapping dict: {mapping_details}")
+
+    cols_with_datatype = {
+        k: v["data_type"]
+        if v["data_type"] not in datatype_remap
+        else datatype_remap[v["data_type"]]
+        for k, v in mapping_details.items()
+        if k in df.columns
+    }
+
+    log.log(config.VERBOSE, f"cols_with_datatype: {cols_with_datatype}")
+
+    result_df = df
+    # result_df = df.astype({k: v for k, v in cols_with_datatype.items()})
+    # result_df = result_df.replace({'NaT': None})
+
+    log.log(
+        config.DATA,
+        f"Data after datatypes\n{result_df.sample(n=config.row_limit).to_markdown()}",
+    )
+
+    return result_df

--- a/migration_steps/transform_casrec/app/transform_data/transform.py
+++ b/migration_steps/transform_casrec/app/transform_data/transform.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 import helpers
 
+from transform_data.apply_datatypes import apply_datatypes
 from utilities.convert_json_to_mappings import MappingDefinitions
 
 from transform_data import calculations as process_calculations
@@ -26,6 +27,7 @@ def perform_transformations(
     source_data_df: pd.DataFrame,
     db_conn_string: str,
     db_schema: str,
+    sirius_details: dict = None,
 ) -> pd.DataFrame:
 
     mapping_defs = MappingDefinitions(mapping_definitions=mapping_definitions)
@@ -69,6 +71,9 @@ def perform_transformations(
         final_df = process_unique_id.add_unique_id(
             db_conn_string, db_schema, table_definition, final_df
         )
+
+    if sirius_details:
+        final_df = apply_datatypes(mapping_details=sirius_details, df=final_df)
 
     log.log(
         config.DATA,

--- a/migration_steps/transform_casrec/app/transform_data/transform.py
+++ b/migration_steps/transform_casrec/app/transform_data/transform.py
@@ -4,6 +4,7 @@ import os
 import pandas as pd
 
 import helpers
+from decorators import timer
 
 from transform_data.apply_datatypes import apply_datatypes
 from utilities.convert_json_to_mappings import MappingDefinitions
@@ -21,6 +22,7 @@ environment = os.environ.get("ENVIRONMENT")
 config = helpers.get_config(env=environment)
 
 
+@timer
 def perform_transformations(
     mapping_definitions: dict,
     table_definition: dict,

--- a/migration_steps/transform_casrec/app/utilities/db_insert.py
+++ b/migration_steps/transform_casrec/app/utilities/db_insert.py
@@ -159,6 +159,19 @@ class InsertData:
 
         return col_diff
 
+    def _add_missing_columns_with_datatypes(
+        self, table_name, col_diff, mapping_details
+    ):
+        statement = f"ALTER TABLE {self.schema}.{table_name} "
+        for i, col in enumerate(col_diff):
+            data_type = mapping_details[col]["data_type"]
+            statement += f'ADD COLUMN "{col}" {data_type}'
+            if i + 1 < len(col_diff):
+                statement += ","
+        statement += ";"
+
+        return statement
+
     def _add_missing_columns(self, table_name, col_diff):
         statement = f"ALTER TABLE {self.schema}.{table_name} "
         for i, col in enumerate(col_diff):
@@ -173,8 +186,6 @@ class InsertData:
 
         t = time.process_time()
 
-        # self.log.info(f"inserting {table_name} into " f"database....")
-        # self.log.debug(df.sample(n=5).to_markdown())
         log.debug(f"inserting {table_name} into " f"database....")
         log.log(config.DATA, f"\n{df.sample(n=config.row_limit).to_markdown()}")
 
@@ -184,9 +195,15 @@ class InsertData:
         if self._check_table_exists(table_name=table_name):
             col_diff = self._check_columns_exist(table_name, df)
             if len(col_diff) > 0:
-                add_missing_colums_statement = self._add_missing_columns(
-                    table_name, col_diff
-                )
+
+                if sirius_details:
+                    add_missing_colums_statement = self._add_missing_columns_with_datatypes(
+                        table_name, col_diff, mapping_details=sirius_details
+                    )
+                else:
+                    add_missing_colums_statement = self._add_missing_columns(
+                        table_name, col_diff
+                    )
                 self.db_engine.execute(add_missing_colums_statement)
         else:
 
@@ -205,12 +222,6 @@ class InsertData:
             self.db_engine.execute(insert_statement)
         except Exception as e:
             log.error(e)
-
-        # inserted_count_statement = self._inserted_count_statement(table_name=table_name)
-        #
-        # inserted_count = self.db_engine.execute(inserted_count_statement).fetchall()[0][
-        #     0
-        # ]
 
         inserted_count = len(df)
 

--- a/migration_steps/transform_casrec/app/utilities/db_insert.py
+++ b/migration_steps/transform_casrec/app/utilities/db_insert.py
@@ -1,3 +1,6 @@
+from typing import Dict
+
+import psycopg2
 import sys
 import os
 from pathlib import Path
@@ -8,6 +11,7 @@ sys.path.insert(0, str(current_path) + "/../../../shared")
 import logging
 import time
 import helpers
+import pandas as pd
 
 log = logging.getLogger("root")
 environment = os.environ.get("ENVIRONMENT")
@@ -19,12 +23,45 @@ class InsertData:
     def __init__(self, db_engine, schema):
         self.db_engine = db_engine
         self.schema = schema
+        self.datatype_remap = {
+            "str": "text",
+            "date": "date",
+            "datetime": "date",
+            "dict": "json",
+        }
 
     def _list_table_columns(self, df):
         return [x for x in df.columns.values]
 
     def _create_schema_statement(self):
         statement = f"CREATE SCHEMA IF NOT EXISTS {self.schema};"
+        return statement
+
+    def _create_table_statement_with_datatype(
+        self, df: pd.DataFrame, mapping_details: Dict, table_name: str
+    ) -> str:
+        log.debug(f"Generating table create statement for {table_name}")
+        statement = f"CREATE TABLE IF NOT EXISTS {self.schema}.{table_name} (\n"
+
+        columns = []
+        for col, details in mapping_details.items():
+            details["data_type"] = (
+                self.datatype_remap[details["data_type"]]
+                if details["data_type"] in self.datatype_remap
+                else details["data_type"]
+            )
+            columns.append(f"{col} {details['data_type']}")
+
+        columns_from_df = self._list_table_columns(df=df)
+        columns_from_mapping = mapping_details.keys()
+        temp_colums = list(set(columns_from_df) - set(columns_from_mapping))
+        for col in temp_colums:
+            columns.append(f"{col} text")
+
+        statement += ", ".join(columns)
+
+        statement += ");"
+        log.log(config.VERBOSE, f"Table create statement: {statement}")
         return statement
 
     def _create_table_statement(self, table_name, df):
@@ -77,10 +114,12 @@ class InsertData:
         insert_statement += ") \n VALUES \n"
 
         for i, row in enumerate(df.values.tolist()):
+
             row = [str(x) for x in row]
             row = [
                 str(
                     x.replace("'", "''")
+                    .replace("NaT", "")
                     .replace("nan", "")
                     .replace("&", "and")
                     .replace(";", "-")
@@ -130,7 +169,7 @@ class InsertData:
 
         return statement
 
-    def insert_data(self, table_name, df):
+    def insert_data(self, table_name, df, sirius_details=None):
 
         t = time.process_time()
 
@@ -150,9 +189,15 @@ class InsertData:
                 )
                 self.db_engine.execute(add_missing_colums_statement)
         else:
-            create_table_statement = self._create_table_statement(
-                table_name=table_name, df=df
-            )
+
+            if sirius_details:
+                create_table_statement = self._create_table_statement_with_datatype(
+                    table_name=table_name, mapping_details=sirius_details, df=df
+                )
+            else:
+                create_table_statement = self._create_table_statement(
+                    table_name=table_name, df=df
+                )
             self.db_engine.execute(create_table_statement)
 
         insert_statement = self._create_insert_statement(table_name=table_name, df=df)

--- a/migration_steps/transform_casrec/app/utilities/db_insert.py
+++ b/migration_steps/transform_casrec/app/utilities/db_insert.py
@@ -5,9 +5,11 @@ import sys
 import os
 from pathlib import Path
 
+
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, str(current_path) + "/../../../shared")
 
+from decorators import timer
 import logging
 import time
 import helpers
@@ -37,6 +39,7 @@ class InsertData:
         statement = f"CREATE SCHEMA IF NOT EXISTS {self.schema};"
         return statement
 
+    @timer
     def _create_table_statement_with_datatype(
         self, df: pd.DataFrame, mapping_details: Dict, table_name: str
     ) -> str:
@@ -182,9 +185,8 @@ class InsertData:
 
         return statement
 
+    @timer
     def insert_data(self, table_name, df, sirius_details=None):
-
-        t = time.process_time()
 
         log.debug(f"inserting {table_name} into " f"database....")
         log.log(config.DATA, f"\n{df.sample(n=config.row_limit).to_markdown()}")
@@ -225,7 +227,4 @@ class InsertData:
 
         inserted_count = len(df)
 
-        log.info(
-            f"Inserted {inserted_count} records into '{table_name}' "
-            f"table in {round(time.process_time() - t, 2)} seconds"
-        )
+        log.info(f"Inserted {inserted_count} records into '{table_name}' table")


### PR DESCRIPTION
Moved datatype stuff into `transform` as it seemed to be repeating a lot of stuff from there.

I've duplicated a couple of methods (the `_create_table_statement` and `_add_missing_columns`) so I could test it out on one table (client_persons) without affecting the others. Seems fine, so next PR will apply the same changes to the other tables and remove the `_with_datatypes` versions of those methods and the conditions.

Also added a generic timer decorator because I started to get worried that adding more to `transform` would slow things down (it doesn't... yet)

