### PR TITLE
If no data in Sirius, return 0

### DIFF
--- a/migration_steps/integration/merge_with_target/app/merge_helpers.py
+++ b/migration_steps/integration/merge_with_target/app/merge_helpers.py
@@ -42,11 +42,19 @@ def get_max_id_from_sirius(db_config, table, id="id"):
 
     try:
         cursor.execute(query)
-        max_id = cursor.fetchall()
-        return max_id[0][0]
+        max_id = cursor.fetchall()[0][0]
+        if max_id:
+            log.debug(f"Max Sirius '{id}' in table '{table}': {max_id}")
+            return max_id
+        else:
+            log.debug(
+                f"No data for Sirius '{id}' in table '{table}', setting max_id to 0"
+            )
+            return 0
+
         cursor.close()
     except (Exception, psycopg2.DatabaseError) as error:
-        print("Error: %s" % error)
+        log.error("Error: %s" % error)
         conn.rollback()
         cursor.close()
         return 1


### PR DESCRIPTION
When calculating the `max_id` from Sirius, if there's no data it would return `None` which is not an int, so you can't add 1 to it to get the next id, and cause problems.

This fixes it 😃 