### PR TITLE
fix an issue with race condition around updating progress table

### DIFF
--- a/migration_steps/prepare/prepare_target/app/app.py
+++ b/migration_steps/prepare/prepare_target/app/app.py
@@ -47,7 +47,7 @@ def main(verbose):
     log.info("Perform Sirius DB Housekeeping")
     conn_target = psycopg2.connect(config.get_db_connection_string("target"))
     conn_source = psycopg2.connect(config.get_db_connection_string("migration"))
-    delete_all_schemas(conn_source)
+    delete_all_schemas(log=log, conn=conn_source)
     log.debug(
         "(operations which need to be performed on Sirius DB ahead of the final Casrec Migration)"
     )

--- a/migration_steps/shared/db_helpers.py
+++ b/migration_steps/shared/db_helpers.py
@@ -10,15 +10,15 @@ from psycopg2.extensions import register_adapter, AsIs
 psycopg2.extensions.register_adapter(np.int64, psycopg2._psycopg.AsIs)
 
 
-def delete_all_schemas(conn):
+def delete_all_schemas(log, conn):
     cursor = conn.cursor()
     get_schemas_statement = f"""
-    SELECT schema_name
-    FROM
-    information_schema.schemata
-    WHERE
-    schema_name not like 'pg_%'
-    and schema_name not in ('public', 'information_schema');
+        SELECT schema_name
+        FROM
+        information_schema.schemata
+        WHERE
+        schema_name not like 'pg_%'
+        and schema_name not in ('public', 'information_schema');
     """
     cursor.execute(get_schemas_statement)
     schemas = ""
@@ -29,7 +29,7 @@ def delete_all_schemas(conn):
         delete_schemas_statement = f"""
         DROP SCHEMA {schemas} CASCADE;
         """
-        print(f"Running '{delete_schemas_statement}'")
+        log.debug(f'Running "{delete_schemas_statement}"')
         cursor.execute(delete_schemas_statement)
         conn.commit()
     cursor.close()


### PR DESCRIPTION
## Purpose

Fix a race condition

## Approach

Do all the setup of progress table prior to grabbing any of the ids. This way when we do the run each process is already allocated to a table. Edge case here is if a process dies then others won't pick up its processes but then again if it dies it fails the step function anyway so whatever. If I was designing something that could never fail ever I wouldn't do it like this but this is like 99.9% and thats good enough i think.

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
