### PR TITLE
IN-599 - make client work on dev env

### DIFF
--- a/migration_steps/integration/integration.sh
+++ b/migration_steps/integration/integration.sh
@@ -3,7 +3,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 python3 "${DIR}/schema_setup/app/app.py"
-python3 "${DIR}/fixtures/app/app.py"
+#python3 "${DIR}/fixtures/app/app.py"
 python3 "${DIR}/merge_with_target/app/app.py" -vv --clear=True
 python3 "${DIR}/load_to_staging/app/app.py" -vv --clear=True
 

--- a/migration_steps/integration/merge_with_target/app/merge_helpers.py
+++ b/migration_steps/integration/merge_with_target/app/merge_helpers.py
@@ -104,7 +104,6 @@ def reindex_new_data(db_config, df, table):
         no_of_rows = len(df.index)
 
         new_df = df[df["method"] == "INSERT"]
-        print(new_df)
 
         new_df = new_df.rename(columns={"id": "transformation_id"})
 

--- a/migration_steps/integration/merge_with_target/app/merge_helpers.py
+++ b/migration_steps/integration/merge_with_target/app/merge_helpers.py
@@ -104,6 +104,7 @@ def reindex_new_data(db_config, df, table):
         no_of_rows = len(df.index)
 
         new_df = df[df["method"] == "INSERT"]
+        print(new_df)
 
         new_df = new_df.rename(columns={"id": "transformation_id"})
 

--- a/migration_steps/load_to_sirius/app/app.py
+++ b/migration_steps/load_to_sirius/app/app.py
@@ -3,6 +3,7 @@ import os
 import sys
 from pathlib import Path
 
+from reset_sequences import reset_all_sequences
 from move import insert_data_into_target
 from move import update_data_in_target
 
@@ -16,12 +17,15 @@ import click
 from sqlalchemy import create_engine
 import custom_logger
 from helpers import log_title
+
 from dotenv import load_dotenv
+
 
 # set config
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 env_path = current_path / "../../.env"
 load_dotenv(dotenv_path=env_path)
+
 environment = os.environ.get("ENVIRONMENT")
 import helpers
 
@@ -90,6 +94,13 @@ def main(verbose, audit):
         log.info(f"Running Post-Audit - Table Copies and Comparisons")
         run_audit(target_db_engine, source_db_engine, "after", log, tables_list)
         log.info(f"Finished Post-Audit - Table Copies and Comparisons")
+
+    # Post migration db jobs
+
+    sequence_list = [
+        {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"}
+    ]
+    reset_all_sequences(sequence_list=sequence_list, db_config=db_config)
 
 
 if __name__ == "__main__":

--- a/migration_steps/load_to_sirius/app/app.py
+++ b/migration_steps/load_to_sirius/app/app.py
@@ -17,6 +17,7 @@ import click
 from sqlalchemy import create_engine
 import custom_logger
 from helpers import log_title
+import table_helpers
 
 from dotenv import load_dotenv
 
@@ -69,11 +70,7 @@ def main(verbose, audit):
     )
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
 
-    path = f"tables.json"
-    log.info(f"path: {path}")
-
-    with open(path) as tables_json:
-        tables_list = json.load(tables_json)
+    tables_list = table_helpers.get_table_list(table_helpers.get_table_file())
 
     if audit:
         log.info(f"Running Pre-Audit - Table Copies")
@@ -96,22 +93,11 @@ def main(verbose, audit):
         log.info(f"Finished Post-Audit - Table Copies and Comparisons")
 
     # Post migration db jobs
-
-    sequence_list = [
-        {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"}
-    ]
+    sequence_list = table_helpers.get_sequences_list(table_helpers.get_table_file())
     reset_all_sequences(sequence_list=sequence_list, db_config=db_config)
-
-    uid_sequence_list = [
-        {
-            "sequence_name": "global_uid_seq",
-            "fields": [
-                {"table": "persons", "column": "uid"},
-                {"table": "cases", "column": "uid"},
-            ],
-        }
-    ]
-
+    uid_sequence_list = table_helpers.get_uid_sequences_list(
+        table_helpers.get_table_file()
+    )
     reset_all_uid_sequences(uid_sequence_list=uid_sequence_list, db_config=db_config)
 
 

--- a/migration_steps/load_to_sirius/app/app.py
+++ b/migration_steps/load_to_sirius/app/app.py
@@ -3,7 +3,7 @@ import os
 import sys
 from pathlib import Path
 
-from reset_sequences import reset_all_sequences
+from reset_sequences import reset_all_sequences, reset_all_uid_sequences
 from move import insert_data_into_target
 from move import update_data_in_target
 
@@ -101,6 +101,18 @@ def main(verbose, audit):
         {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"}
     ]
     reset_all_sequences(sequence_list=sequence_list, db_config=db_config)
+
+    uid_sequence_list = [
+        {
+            "sequence_name": "global_uid_seq",
+            "fields": [
+                {"table": "persons", "column": "uid"},
+                {"table": "cases", "column": "uid"},
+            ],
+        }
+    ]
+
+    reset_all_uid_sequences(uid_sequence_list=uid_sequence_list, db_config=db_config)
 
 
 if __name__ == "__main__":

--- a/migration_steps/load_to_sirius/app/reset_sequences.py
+++ b/migration_steps/load_to_sirius/app/reset_sequences.py
@@ -6,17 +6,6 @@ import psycopg2
 log = logging.getLogger("root")
 
 
-uid_sequence_list = [
-    {
-        "sequence_name": "global_uid_seq",
-        "fields": [
-            {"table": "persons", "column": "uid"},
-            {"table": "cases", "column": "uid"},
-        ],
-    }
-]
-
-
 def reset_all_sequences(sequence_list, db_config):
     for seq in sequence_list:
         log.info(f"Resetting sequence {seq['sequence_name']}")
@@ -35,6 +24,60 @@ def reset_sequence(sequence_details, db_config):
 
     try:
         cursor.execute(query)
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+
+
+def reset_all_uid_sequences(uid_sequence_list, db_config):
+    for seq in uid_sequence_list:
+        log.info(f"Resetting UID sequence {seq['sequence_name']}")
+        reset_uid_sequence(sequence_details=seq, db_config=db_config)
+
+
+def reset_uid_sequence(sequence_details, db_config):
+    table_subquery = ""
+    for i, table in enumerate(sequence_details["fields"]):
+        single_table_subquery = (
+            f"SELECT MAX({table['column']}) AS uid FROM {table['table']}"
+        )
+        if i + 1 < len(sequence_details["fields"]):
+            single_table_subquery += " UNION ALL "
+        table_subquery += single_table_subquery
+
+    query = f"""
+        WITH uids AS (
+            {table_subquery}
+        )
+        SELECT MAX(uid) from uids;
+    """
+
+    log.debug(query)
+
+    connection_string = db_config["target_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(query)
+        max_uid = cursor.fetchall()[0][0]
+
+        log.debug(f"max_uid: {max_uid}")
+
+        min_uid = 70000000000
+        max_sequence_val = int(str(max_uid)[:-1]) - min_uid
+
+        log.debug(f"max_sequence_val: {max_sequence_val}")
+
+        reset_query = f"""
+            SELECT setval('{sequence_details['sequence_name']}', {max_sequence_val});
+        """
+        log.debug(reset_query)
+
+        cursor.execute(reset_query)
+
         cursor.close()
     except (Exception, psycopg2.DatabaseError) as error:
         log.error("Error: %s" % error)

--- a/migration_steps/load_to_sirius/app/reset_sequences.py
+++ b/migration_steps/load_to_sirius/app/reset_sequences.py
@@ -1,0 +1,42 @@
+from typing import List, Dict
+import logging
+
+import psycopg2
+
+log = logging.getLogger("root")
+
+
+uid_sequence_list = [
+    {
+        "sequence_name": "global_uid_seq",
+        "fields": [
+            {"table": "persons", "column": "uid"},
+            {"table": "cases", "column": "uid"},
+        ],
+    }
+]
+
+
+def reset_all_sequences(sequence_list, db_config):
+    for seq in sequence_list:
+        log.info(f"Resetting sequence {seq['sequence_name']}")
+        reset_sequence(sequence_details=seq, db_config=db_config)
+
+
+def reset_sequence(sequence_details, db_config):
+
+    query = f"""
+        SELECT setval('{sequence_details['sequence_name']}', (SELECT MAX ({sequence_details['column']}) FROM {sequence_details['table']}));
+    """
+
+    connection_string = db_config["target_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(query)
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()

--- a/migration_steps/shared/shared_tests/table_helpers/test_get_tables.py
+++ b/migration_steps/shared/shared_tests/table_helpers/test_get_tables.py
@@ -1,0 +1,83 @@
+from migration_steps.shared.table_helpers import (
+    get_table_list,
+    get_sequences_list,
+    get_uid_sequences_list,
+)
+
+test_data = {
+    "persons": {
+        "sequences": [
+            {"name": "persons_id_seq", "column": "id", "type": "pk"},
+            {"name": "global_uid_seq", "column": "uid", "type": "uid"},
+        ]
+    },
+    "addresses": {
+        "sequences": [{"name": "addresses_id_seq", "column": "id", "type": "pk"}]
+    },
+    "phonenumbers": {
+        "sequences": [{"name": "phonenumbers_id_seq", "column": "id", "type": "pk"}]
+    },
+    "cases": {
+        "sequences": [
+            {"name": "cases_id_seq", "column": "id", "type": "pk"},
+            {"name": "global_uid_seq", "column": "uid", "type": "uid"},
+        ]
+    },
+    "person_caseitem": {
+        "sequences": [{"name": "person_caseitem_id_seq", "column": "id", "type": "pk"}]
+    },
+    "supervision_level_log": {
+        "sequences": [
+            {"name": "supervision_level_log_id_seq", "column": "id", "type": "pk"}
+        ]
+    },
+}
+
+
+def test_get_table_list():
+    result = get_table_list(table_dict=test_data)
+    assert result == [
+        "persons",
+        "addresses",
+        "phonenumbers",
+        "cases",
+        "person_caseitem",
+        "supervision_level_log",
+    ]
+
+
+def test_get_sequences_list():
+    result = get_sequences_list(table_dict=test_data)
+    assert result == [
+        {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"},
+        {"sequence_name": "addresses_id_seq", "table": "addresses", "column": "id"},
+        {
+            "sequence_name": "phonenumbers_id_seq",
+            "table": "phonenumbers",
+            "column": "id",
+        },
+        {"sequence_name": "cases_id_seq", "table": "cases", "column": "id"},
+        {
+            "sequence_name": "person_caseitem_id_seq",
+            "table": "person_caseitem",
+            "column": "id",
+        },
+        {
+            "sequence_name": "supervision_level_log_id_seq",
+            "table": "supervision_level_log",
+            "column": "id",
+        },
+    ]
+
+
+def test_get_uid_sequences_list():
+    result = get_uid_sequences_list(table_dict=test_data)
+    assert result == [
+        {
+            "sequence_name": "global_uid_seq",
+            "fields": [
+                {"table": "persons", "column": "uid"},
+                {"table": "cases", "column": "uid"},
+            ],
+        }
+    ]

--- a/migration_steps/shared/table_helpers.py
+++ b/migration_steps/shared/table_helpers.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+
+def get_current_directory():
+    dirname = os.path.dirname(__file__)
+    return dirname
+
+
+def get_table_file(file_name="tables"):
+    dirname = get_current_directory()
+    file_path = os.path.join(dirname, f"{file_name}.json")
+
+    with open(file_path) as tables_json:
+        tables_dict = json.load(tables_json)
+
+    return tables_dict
+
+
+def get_table_list(table_dict):
+    return list(table_dict.keys())
+
+
+def get_sequences_list(table_dict):
+    sequence_list = []
+    for table, details in table_dict.items():
+        for seq in details["sequences"]:
+            if seq["type"] == "pk":
+                table_seq = {
+                    "sequence_name": seq["name"],
+                    "table": table,
+                    "column": seq["column"],
+                }
+                sequence_list.append(table_seq)
+    return sequence_list
+
+
+def get_uid_sequences_list(table_dict):
+    sequence_list = []
+    for table, details in table_dict.items():
+        for seq in details["sequences"]:
+            if seq["type"] == "uid":
+                if any(seq["name"] in x["sequence_name"] for x in sequence_list):
+                    additional_fields = {"table": table, "column": seq["column"]}
+
+                    pos = [
+                        i
+                        for i, s in enumerate(sequence_list)
+                        if seq["name"] in s["sequence_name"]
+                    ][0]
+                    sequence_list[pos]["fields"].append(additional_fields)
+                else:
+                    table_seq = {
+                        "sequence_name": seq["name"],
+                        "fields": [{"table": table, "column": seq["column"]}],
+                    }
+                    sequence_list.append(table_seq)
+    return sequence_list

--- a/migration_steps/shared/tables.json
+++ b/migration_steps/shared/tables.json
@@ -1,0 +1,48 @@
+{
+	"persons": {
+		"sequences": [{
+			"name": "persons_id_seq",
+			"column": "id",
+			"type": "pk"
+		},{
+			"name": "global_uid_seq",
+			"column": "id",
+			"type": "uid"
+		}]
+	},
+	"addresses": {
+		"sequences": [{
+			"name": "addresses_id_seq",
+			"column": "id",
+			"type": "pk"
+		}]
+	},
+	"phonenumbers": {
+		"sequences": [{
+			"name": "phonenumbers_id_seq",
+			"column": "id",
+			"type": "pk"
+		}]
+	},
+	"cases": {
+		"sequences": [{
+			"name": "cases_id_seq",
+			"column": "id",
+			"type": "pk"
+		},{
+			"name": "global_uid_seq",
+			"column": "id",
+			"type": "uid"
+		}]
+	},
+	"person_caseitem": {
+		"sequences": []
+	},
+	"supervision_level_log": {
+		"sequences": [{
+			"name": "supervision_level_log_id_seq",
+			"column": "id",
+			"type": "pk"
+		}]
+	}
+}

--- a/migration_steps/shared/tables.json
+++ b/migration_steps/shared/tables.json
@@ -6,7 +6,7 @@
 			"type": "pk"
 		},{
 			"name": "global_uid_seq",
-			"column": "id",
+			"column": "uid",
 			"type": "uid"
 		}]
 	},
@@ -31,7 +31,7 @@
 			"type": "pk"
 		},{
 			"name": "global_uid_seq",
-			"column": "id",
+			"column": "uid",
 			"type": "uid"
 		}]
 	},

--- a/migration_steps/validation-dockerfile
+++ b/migration_steps/validation-dockerfile
@@ -4,5 +4,6 @@ COPY validation/requirements.txt /requirements.txt
 RUN pip3 install -r requirements.txt
 COPY validation/validate.sh /validation/validate.sh
 COPY validation/validate_db /validation/validate_db
+COPY validation/post_migration_tests /validation/post_migration_tests
 COPY shared /shared
 CMD ["echo", "NO_OP"]

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -3,10 +3,13 @@ import os
 import sys
 from pathlib import Path
 
+from tabulate import tabulate
+
 from checks.address_lines import check_address_line_format
 from checks.continuous_ids import check_continuous
 from checks.sequences import check_sequences
 from checks.uid_sequence import check_uid_sequences
+from utilities import format_report
 
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, str(current_path) + "/../../../shared")
@@ -80,18 +83,24 @@ def main(verbose):
     with open(path) as tables_json:
         table_list = json.load(tables_json)
 
+    tests = []
     sequences = check_sequences(sequences=sequence_list, db_config=db_config)
-    log.info(f"Sequences: {sequences}")
+    tests.append({"name": "Sequences", "result": sequences})
     uid_sequences = check_uid_sequences(
         sequences=uid_sequence_list, db_config=db_config
     )
-    log.info(f"UID Sequences: {uid_sequences}")
+    tests.append({"name": "UID Sequences", "result": uid_sequences})
 
     continuous_ids = check_continuous(table_list=table_list, db_config=db_config)
-    log.info(f"continuous_ids: {continuous_ids}")
+    tests.append({"name": "Continuous IDs", "result": continuous_ids})
 
+    # This should be in data validation - once it's added in there remove here pls
     address_line_format = check_address_line_format(db_config=db_config)
-    log.info(f"address_line_format: {address_line_format}")
+    tests.append({"name": "Address Line Formatting", "result": address_line_format})
+
+    report = format_report(tests)
+
+    print(report)
 
 
 if __name__ == "__main__":

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -1,0 +1,76 @@
+import os
+import sys
+from pathlib import Path
+
+from checks.sequences import check_sequences
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import logging
+import time
+import click
+from sqlalchemy import create_engine
+import custom_logger
+from helpers import log_title
+
+from dotenv import load_dotenv
+
+
+# set config
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+env_path = current_path / "../../.env"
+load_dotenv(dotenv_path=env_path)
+
+environment = os.environ.get("ENVIRONMENT")
+import helpers
+
+config = helpers.get_config(env=environment)
+
+# logging
+# custom_logger.custom_log_level(levels=config.custom_log_levels)
+config.custom_log_level()
+verbosity_levels = config.verbosity_levels
+log = logging.getLogger("root")
+log.addHandler(custom_logger.MyHandler())
+
+# database
+db_config = {
+    "source_db_connection_string": config.get_db_connection_string("migration"),
+    "sirius_db_connection_string": config.get_db_connection_string("target"),
+    "source_schema": config.schemas["pre_migration"],
+    "sirius_schema": config.schemas["public"],
+}
+# source_db_engine = create_engine(db_config["source_db_connection_string"])
+# target_db_engine = create_engine(db_config["target_db_connection_string"])
+
+
+@click.command()
+@click.option("-v", "--verbose", count=True)
+def main(verbose):
+    try:
+        log.setLevel(verbosity_levels[verbose])
+        log.info(f"{verbosity_levels[verbose]} logging enabled")
+    except KeyError:
+        log.setLevel("INFO")
+        log.info(f"{verbose} is not a valid verbosity level")
+        log.info(f"INFO logging enabled")
+
+    log.info(log_title(message="Validation Step: check things that are not just data"))
+
+    log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
+
+    sequence_list = [
+        {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"}
+    ]
+
+    sequences = check_sequences(sequences=sequence_list, db_config=db_config)
+    log.info(f"Sequences: {sequences}")
+
+
+if __name__ == "__main__":
+    t = time.process_time()
+
+    main()
+
+    print(f"Total time: {round(time.process_time() - t, 2)}")

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -31,6 +31,7 @@ load_dotenv(dotenv_path=env_path)
 
 environment = os.environ.get("ENVIRONMENT")
 import helpers
+import table_helpers
 
 config = helpers.get_config(env=environment)
 
@@ -67,21 +68,11 @@ def main(verbose):
 
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
 
-    sequence_list = [
-        {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"}
-    ]
-    uid_sequence_list = [
-        {
-            "sequence_name": "global_uid_seq",
-            "fields": [
-                {"table": "persons", "column": "uid"},
-                {"table": "cases", "column": "uid"},
-            ],
-        }
-    ]
-    path = f"{os.path.dirname(__file__)}/tables.json"
-    with open(path) as tables_json:
-        table_list = json.load(tables_json)
+    table_list = table_helpers.get_table_list(table_helpers.get_table_file())
+    sequence_list = table_helpers.get_sequences_list(table_helpers.get_table_file())
+    uid_sequence_list = table_helpers.get_uid_sequences_list(
+        table_helpers.get_table_file()
+    )
 
     tests = []
     sequences = check_sequences(sequences=sequence_list, db_config=db_config)

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+from checks.continuous_ids import check_continuous
 from checks.sequences import check_sequences
 from checks.uid_sequence import check_uid_sequences
 
@@ -73,6 +74,7 @@ def main(verbose):
             ],
         }
     ]
+    table_list = ["persons"]
 
     sequences = check_sequences(sequences=sequence_list, db_config=db_config)
     log.info(f"Sequences: {sequences}")
@@ -80,6 +82,9 @@ def main(verbose):
         sequences=uid_sequence_list, db_config=db_config
     )
     log.info(f"UID Sequences: {uid_sequences}")
+
+    continuous_ids = check_continuous(table_list=table_list, db_config=db_config)
+    log.info(f"continuous_ids: {continuous_ids}")
 
 
 if __name__ == "__main__":

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from pathlib import Path
@@ -74,7 +75,9 @@ def main(verbose):
             ],
         }
     ]
-    table_list = ["persons"]
+    path = f"{os.path.dirname(__file__)}/tables.json"
+    with open(path) as tables_json:
+        table_list = json.load(tables_json)
 
     sequences = check_sequences(sequences=sequence_list, db_config=db_config)
     log.info(f"Sequences: {sequences}")

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -3,6 +3,7 @@ import os
 import sys
 from pathlib import Path
 
+from checks.address_lines import check_address_line_format
 from checks.continuous_ids import check_continuous
 from checks.sequences import check_sequences
 from checks.uid_sequence import check_uid_sequences
@@ -88,6 +89,9 @@ def main(verbose):
 
     continuous_ids = check_continuous(table_list=table_list, db_config=db_config)
     log.info(f"continuous_ids: {continuous_ids}")
+
+    address_line_format = check_address_line_format(db_config=db_config)
+    log.info(f"address_line_format: {address_line_format}")
 
 
 if __name__ == "__main__":

--- a/migration_steps/validation/post_migration_tests/app/app.py
+++ b/migration_steps/validation/post_migration_tests/app/app.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 from checks.sequences import check_sequences
+from checks.uid_sequence import check_uid_sequences
 
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, str(current_path) + "/../../../shared")
@@ -63,9 +64,22 @@ def main(verbose):
     sequence_list = [
         {"sequence_name": "persons_id_seq", "table": "persons", "column": "id"}
     ]
+    uid_sequence_list = [
+        {
+            "sequence_name": "global_uid_seq",
+            "fields": [
+                {"table": "persons", "column": "uid"},
+                {"table": "cases", "column": "uid"},
+            ],
+        }
+    ]
 
     sequences = check_sequences(sequences=sequence_list, db_config=db_config)
     log.info(f"Sequences: {sequences}")
+    uid_sequences = check_uid_sequences(
+        sequences=uid_sequence_list, db_config=db_config
+    )
+    log.info(f"UID Sequences: {uid_sequences}")
 
 
 if __name__ == "__main__":

--- a/migration_steps/validation/post_migration_tests/app/checks/address_lines.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/address_lines.py
@@ -1,0 +1,85 @@
+import random
+from typing import List, Dict
+import logging
+
+import psycopg2
+
+log = logging.getLogger("root")
+
+
+def get_min_and_max_address_ids(db_config):
+    query = f"""
+        SELECT min(id), max(id) from {db_config['source_schema']}.addresses
+    """
+
+    connection_string = db_config["source_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(query)
+
+        ids = cursor.fetchall()[0]
+
+        if ids:
+            log.debug(f"Min & max address ids in staging: {ids[0]}, {ids[1]}")
+            return (ids[0], ids[1])
+        else:
+            log.debug(f"No data for staging min and max address ids, setting both to 0")
+            return (0, 0)
+
+        # cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+        return 0
+
+
+def get_random_address_lines(db_config, min, max, number_of_lines):
+    table = "addresses"
+    column = "address_lines"
+
+    ids_to_check = random.sample(range(min, max), number_of_lines)
+    log.debug(f"Checking ids: {', '.join([str(x) for x in ids_to_check])}")
+
+    query = f"""
+        SELECT {column} FROM {table}
+        WHERE id in ({', '.join([str(x) for x in ids_to_check])})
+    """
+
+    connection_string = db_config["sirius_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(query)
+        lines = cursor.fetchall()
+        if lines:
+            log.debug(f"{number_of_lines} lines retrieved")
+
+            return lines
+        else:
+            log.debug(f"No data for address lines with ids {', '.join(ids_to_check)}")
+            return 0
+
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+        return 0
+
+
+def check_address_line_format(db_config, number_of_lines=10):
+    min, max = get_min_and_max_address_ids(db_config)
+
+    address_lines = get_random_address_lines(
+        db_config=db_config, min=min, max=max, number_of_lines=number_of_lines
+    )
+
+    type_check = [type(x[0]) == list for x in address_lines]
+    if False in type_check:
+        return False
+    else:
+        return True

--- a/migration_steps/validation/post_migration_tests/app/checks/address_lines.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/address_lines.py
@@ -78,15 +78,19 @@ def check_address_line_format(db_config, number_of_lines=10):
         db_config=db_config, min=min, max=max, number_of_lines=number_of_lines
     )
 
-    type_check = [type(x[0]) == list for x in address_lines]
-    passes = len([x for x in type_check if x == True])
-    fails = len([x for x in type_check if x == False])
-    report = {
-        "pass": [f"{passes}/{number_of_lines}"],
-        "fail": [f"{fails}/{number_of_lines}"],
-    }
+    try:
+        type_check = [type(x[0]) == list for x in address_lines]
+        passes = len([x for x in type_check if x == True])
+        fails = len([x for x in type_check if x == False])
+        report = {
+            "pass": [f"{passes}/{number_of_lines}"],
+            "fail": [f"{fails}/{number_of_lines}"],
+        }
 
-    if False in type_check:
+        if False in type_check:
+            return (False, report)
+        else:
+            return (True, report)
+    except Exception:
+        report = {"other": "Test failed to run"}
         return (False, report)
-    else:
-        return (True, report)

--- a/migration_steps/validation/post_migration_tests/app/checks/address_lines.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/address_lines.py
@@ -79,7 +79,14 @@ def check_address_line_format(db_config, number_of_lines=10):
     )
 
     type_check = [type(x[0]) == list for x in address_lines]
+    passes = len([x for x in type_check if x == True])
+    fails = len([x for x in type_check if x == False])
+    report = {
+        "pass": [f"{passes}/{number_of_lines}"],
+        "fail": [f"{fails}/{number_of_lines}"],
+    }
+
     if False in type_check:
-        return False
+        return (False, report)
     else:
-        return True
+        return (True, report)

--- a/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
@@ -81,8 +81,7 @@ def check_continuous(table_list, db_config):
         else:
             report["fail"].append(table)
 
-    log.info(report)
     if len(report["fail"]) == 0:
-        return True
+        return (True, report)
     else:
-        return False
+        return (False, report)

--- a/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
@@ -38,12 +38,12 @@ def get_min_migrated_record(db_config, table, column="id"):
 
 
 def get_previous_original_record(db_config, table, col_value, column="id"):
-    connection_string = db_config["sirius_db_connection_string"]
-    conn = psycopg2.connect(connection_string)
-    cursor = conn.cursor()
 
     query = f"SELECT max({column}) from {db_config['sirius_schema']}.{table} WHERE {column} < {col_value};"
 
+    connection_string = db_config["sirius_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
     try:
         cursor.execute(query)
         previous_value = cursor.fetchall()[0][0]
@@ -67,6 +67,7 @@ def get_previous_original_record(db_config, table, col_value, column="id"):
 
 
 def check_continuous(table_list, db_config):
+    table_list.remove("person_caseitem")
     report = {"pass": [], "fail": []}
 
     for table in table_list:

--- a/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
@@ -1,0 +1,88 @@
+from typing import List, Dict
+import logging
+
+import psycopg2
+
+log = logging.getLogger("root")
+
+
+def get_table_list():
+    return ["persons"]
+
+
+def get_min_migrated_record(db_config, table, column="id"):
+    connection_string = db_config["source_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    query = f"SELECT min({column}) from {db_config['source_schema']}.{table};"
+
+    try:
+        cursor.execute(query)
+        min_id = cursor.fetchall()[0][0]
+        if min_id:
+            log.debug(f"Min staging '{column}' in table '{table}': {min_id}")
+            return min_id
+        else:
+            log.debug(
+                f"No data for Sirius '{column}' in table '{table}', setting min_id to 0"
+            )
+            return 0
+
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+        return 0
+
+
+def get_previous_original_record(db_config, table, col_value, column="id"):
+    connection_string = db_config["sirius_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    query = f"SELECT max({column}) from {db_config['sirius_schema']}.{table} WHERE {column} < {col_value};"
+
+    try:
+        cursor.execute(query)
+        previous_value = cursor.fetchall()[0][0]
+        if previous_value:
+            log.debug(
+                f"Previous Sirius '{column}' in table '{table}': {previous_value}"
+            )
+            return previous_value
+        else:
+            log.debug(
+                f"No data for previous Sirius '{column}' in table '{table}', setting previous_value to 0"
+            )
+            return 0
+
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+        return 0
+
+
+def check_continuous(table_list, db_config):
+    report = {"pass": [], "fail": []}
+
+    for table in table_list:
+        first_migrated_record = get_min_migrated_record(
+            db_config=db_config, table=table
+        )
+        last_original_record = get_previous_original_record(
+            db_config=db_config, table=table, col_value=first_migrated_record
+        )
+        if last_original_record + 1 == first_migrated_record:
+            report["pass"].append(table)
+        else:
+            report["fail"].append(table)
+
+    log.info(report)
+    if len(report["fail"]) == 0:
+        return True
+    else:
+        return False

--- a/migration_steps/validation/post_migration_tests/app/checks/sequences.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/sequences.py
@@ -82,8 +82,7 @@ def check_sequences(sequences: List[Dict], db_config: Dict) -> bool:
         else:
             report["fail"].append(sequence["sequence_name"])
 
-    log.info(report)
     if len(report["fail"]) == 0:
-        return True
+        return (True, report)
     else:
-        return False
+        return (False, report)

--- a/migration_steps/validation/post_migration_tests/app/checks/sequences.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/sequences.py
@@ -1,0 +1,88 @@
+from typing import List, Dict
+import logging
+
+import psycopg2
+
+log = logging.getLogger("root")
+
+
+def get_max_value(table, column, db_config):
+    connection_string = db_config["sirius_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    query = f"SELECT max({column}) from {db_config['sirius_schema']}.{table};"
+
+    try:
+        cursor.execute(query)
+        max_id = cursor.fetchall()[0][0]
+        if max_id:
+            log.debug(f"Max Sirius '{column}' in table '{table}': {max_id}")
+            return max_id
+        else:
+            log.debug(
+                f"No data for Sirius '{column}' in table '{table}', setting max_id to 0"
+            )
+            return 0
+
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+        return 0
+
+
+def get_sequence_currval(sequence_name, db_config):
+    query = f"""SELECT last_value FROM {sequence_name};"""
+
+    connection_string = db_config["sirius_db_connection_string"]
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(query)
+        curr_id = cursor.fetchall()[0][0]
+        if curr_id:
+            log.debug(f"Current value of sequence '{sequence_name}' is {curr_id}")
+            return curr_id
+        else:
+            log.debug(f"No data for Sirius '{sequence_name}' something went wrong")
+            return 0
+
+        cursor.close()
+    except (Exception, psycopg2.DatabaseError) as error:
+        log.error("Error: %s" % error)
+        conn.rollback()
+        cursor.close()
+        return 0
+
+
+def check_sequences(sequences: List[Dict], db_config: Dict) -> bool:
+    """
+    check that the next value of the sequence has been reset correctly
+    after the migrated data was inserted
+    """
+
+    report = {"pass": [], "fail": []}
+
+    for sequence in sequences:
+
+        current_sequence_value = get_sequence_currval(
+            sequence_name=sequence["sequence_name"], db_config=db_config
+        )
+        max_column_value = get_max_value(
+            table=sequence["table"], column=sequence["column"], db_config=db_config
+        )
+
+        if current_sequence_value == max_column_value:
+            report["pass"].append(sequence["sequence_name"])
+
+        else:
+            report["fail"].append(sequence["sequence_name"])
+
+    log.info(report)
+    if len(report["fail"]) == 0:
+        return True
+    else:
+        return False

--- a/migration_steps/validation/post_migration_tests/app/checks/uid_sequence.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/uid_sequence.py
@@ -100,8 +100,7 @@ def check_uid_sequences(sequences: List[Dict], db_config: Dict) -> bool:
             )
             report["fail"].append(sequence["sequence_name"])
 
-    log.info(report)
     if len(report["fail"]) == 0:
-        return True
+        return (True, report)
     else:
-        return False
+        return (False, report)

--- a/migration_steps/validation/post_migration_tests/app/tables.json
+++ b/migration_steps/validation/post_migration_tests/app/tables.json
@@ -1,7 +1,0 @@
-[
-  "persons",
-  "addresses",
-  "phonenumbers",
-  "cases",
-  "supervision_level_log"
-]

--- a/migration_steps/validation/post_migration_tests/app/tables.json
+++ b/migration_steps/validation/post_migration_tests/app/tables.json
@@ -3,6 +3,5 @@
   "addresses",
   "phonenumbers",
   "cases",
-  "person_caseitem",
   "supervision_level_log"
 ]

--- a/migration_steps/validation/post_migration_tests/app/tables.json
+++ b/migration_steps/validation/post_migration_tests/app/tables.json
@@ -1,0 +1,8 @@
+[
+  "persons",
+  "addresses",
+  "phonenumbers",
+  "cases",
+  "person_caseitem",
+  "supervision_level_log"
+]

--- a/migration_steps/validation/post_migration_tests/app/utilities.py
+++ b/migration_steps/validation/post_migration_tests/app/utilities.py
@@ -22,6 +22,7 @@ def format_details(details):
 
 
 def format_report(list_of_tests):
+    print(list_of_tests)
     report = []
     for t in list_of_tests:
         if t["result"][0]:

--- a/migration_steps/validation/post_migration_tests/app/utilities.py
+++ b/migration_steps/validation/post_migration_tests/app/utilities.py
@@ -4,16 +4,19 @@ from tabulate import tabulate
 
 def format_details(details):
     report = ""
+    if "other" in details:
+        row = Fore.CYAN + "test failed to run" + Fore.RESET + "\n"
+        report += row
+    if "fail" in details and len(details["fail"]) == 0:
+        row = Fore.GREEN + "n/a" + Fore.RESET + "\n"
+        report += row
     try:
         for i in details["fail"]:
             row = Fore.RED + i + Fore.RESET + "\n"
             report += row
-        if len(details["fail"]) == 0:
-            row = Fore.GREEN + "n/a" + Fore.RESET + "\n"
-            report += row
     except KeyError:
         row = Fore.GREEN + "n/a" + Fore.RESET + "\n"
-        report += row
+        # report += row
 
     return report
 
@@ -23,15 +26,17 @@ def format_report(list_of_tests):
     for t in list_of_tests:
         if t["result"][0]:
             colour = Fore.GREEN
+            char = u"\u2713"
         else:
             colour = Fore.RED
+            char = u"\u02DF"
 
         failure_details = format_details(details=t["result"][1])
 
         row = [
             t["name"],
             failure_details,
-            colour + str(t["result"][0]) + Fore.RESET,
+            colour + char + Fore.RESET,
         ]
         report.append(row)
     return tabulate(

--- a/migration_steps/validation/post_migration_tests/app/utilities.py
+++ b/migration_steps/validation/post_migration_tests/app/utilities.py
@@ -1,0 +1,39 @@
+from colorama import init, Back, Fore
+from tabulate import tabulate
+
+
+def format_details(details):
+    report = ""
+    try:
+        for i in details["fail"]:
+            row = Fore.RED + i + Fore.RESET + "\n"
+            report += row
+        if len(details["fail"]) == 0:
+            row = Fore.GREEN + "n/a" + Fore.RESET + "\n"
+            report += row
+    except KeyError:
+        row = Fore.GREEN + "n/a" + Fore.RESET + "\n"
+        report += row
+
+    return report
+
+
+def format_report(list_of_tests):
+    report = []
+    for t in list_of_tests:
+        if t["result"][0]:
+            colour = Fore.GREEN
+        else:
+            colour = Fore.RED
+
+        failure_details = format_details(details=t["result"][1])
+
+        row = [
+            t["name"],
+            failure_details,
+            colour + str(t["result"][0]) + Fore.RESET,
+        ]
+        report.append(row)
+    return tabulate(
+        report, headers=["test", "failure details", "success"], tablefmt="pretty"
+    )

--- a/migration_steps/validation/post_migration_tests/post_mig_tests/conftest.py
+++ b/migration_steps/validation/post_migration_tests/post_mig_tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+import os
+import sys
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import helpers
+
+
+@pytest.fixture(autouse=True, scope="function")
+def get_test_config(monkeypatch):
+    def local_config():
+        print("Using test config")
+
+    monkeypatch.setattr(helpers, "get_config", local_config)

--- a/migration_steps/validation/post_migration_tests/post_mig_tests/sequences/test_sequences.py
+++ b/migration_steps/validation/post_migration_tests/post_mig_tests/sequences/test_sequences.py
@@ -1,0 +1,44 @@
+import pytest
+
+from checks import sequences
+
+test_sequence = [
+    {"sequence_name": "seq_no_match", "table": "table", "column": "column"},
+    {"sequence_name": "seq_no_match_2", "table": "table", "column": "column"},
+]
+
+
+def test_check_sequences_fail(monkeypatch):
+    expected_result = False
+
+    def mock_get_max_value(*args, **kwargs):
+        return 5
+
+    monkeypatch.setattr(sequences, "get_max_value", mock_get_max_value)
+
+    def mock_get_sequence_currval(*args, **kwargs):
+        return 6
+
+    monkeypatch.setattr(sequences, "get_sequence_currval", mock_get_sequence_currval)
+
+    result = sequences.check_sequences(sequences=test_sequence, db_config={})
+
+    assert result == expected_result
+
+
+def test_check_sequences_pass(monkeypatch):
+    expected_result = True
+
+    def mock_get_max_value(*args, **kwargs):
+        return 6
+
+    monkeypatch.setattr(sequences, "get_max_value", mock_get_max_value)
+
+    def mock_get_sequence_currval(*args, **kwargs):
+        return 6
+
+    monkeypatch.setattr(sequences, "get_sequence_currval", mock_get_sequence_currval)
+
+    result = sequences.check_sequences(sequences=test_sequence, db_config={})
+
+    assert result == expected_result

--- a/migration_steps/validation/requirements.txt
+++ b/migration_steps/validation/requirements.txt
@@ -1,1 +1,2 @@
 tabulate
+colorama

--- a/migration_steps/validation/validate.sh
+++ b/migration_steps/validation/validate.sh
@@ -3,3 +3,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 python3 "${DIR}/validate_db/app/app.py" "$@"
+python3 "${DIR}/post_migration_tests/app/app.py" -vv


### PR DESCRIPTION
**Aim**
Get clients to work on the dev env

**What I did and why I did it:**

- added some post-migration tests 
Tacked on to the `validation` step. These check the stuff below - that the sequences have been reset as expected, and that the ids we inserted are continuous (this is not really important but I was confused about why our migrated data started with id 1000 when the max of the existing data was 82).
This includes a test for badly formatted address lines which is also not necessary, but I spotted it on dev and added it. This should be moved into the data validation soon, then this can be removed. I just got a bit overexcited at the time.
There's also some tests for the tests :D


- added functions to reset sequences
This was the major problem with dev. Remember those primary keys that didn't use sequences? Well, they do, they just don't use the db sequence directly. We were unable to add a new client because the id had already been used, resetting the sequence to the max of the new data fixes it. Needed doing for every table with a (non)autoincrementing id and for uids.


- moved `tables.json` into `shared` folder
I needed this in 2 places so instead of copy/pasting I moved it into `shared` and added some methods to access the data in different ways (plus tests)



- removed the sirius test fixtures
These were causing the 'continuous ids' test to fail, not sure why but given we're about to change how the fixtures etc work I figured (not necessarily permanently...) removing this would not be a big deal

- added another fk join to `cases`
Turns out a case is linked to a client not just via `persons_caseitem` but also the `client_id` on `cases` so added this in. May require tweaking if it turns out it's not a straightforward join but works for now, and allows orders to be visible on a client on the frontend

