### PR TITLE
SP-604 - Deny None SSL Requests to S3 Bucket

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -56,4 +56,25 @@ data "aws_iam_policy_document" "casrec_migration" {
       variable = "s3:x-amz-server-side-encryption"
     }
   }
+
+  statement {
+    sid     = "DenyNoneSSLRequests"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      aws_s3_bucket.casrec_migration.arn,
+      "${aws_s3_bucket.casrec_migration.arn}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
 }


### PR DESCRIPTION
## Purpose

Add S3 Bucket Policy to deny none SSL requests to the bucket to bring it in line with Security Hub recommendations.

## Approach

Re-used proven policy from main Sirius Infra repo.


## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
