### PR TITLE
IN-608 deputy phonenumbers

### DIFF
--- a/migration_steps/transform_casrec/app/data_tests/cases/cases_person_caseitem.py
+++ b/migration_steps/transform_casrec/app/data_tests/cases/cases_person_caseitem.py
@@ -11,6 +11,7 @@ destination_tables = {
     "child": "cases",
     "join_table": "person_caseitem",
 }
+json_files = {"parent": "client_persons_mapping", "child": "cases_mapping"}
 
 
 @case(tags="many_to_one_join")
@@ -40,9 +41,10 @@ def case_person_caseitem(test_config):
             on cast({destination_tables['join_table']}.person_id as int)
                 = cast({destination_tables['parent']}.id as int)
         LEFT OUTER JOIN {config.schemas['post_transform']}.{destination_tables['child']}
-            on cast({destination_tables['join_table']}.case_id as int)
+            on cast({destination_tables['join_table']}.caseitem_id as int)
                 = cast({destination_tables['child']}.id as int)
-        WHERE {destination_tables['parent']}."type" = 'actor_client'
+            AND {destination_tables['child']}.casrec_mapping_file_name = '{json_files['child']}'
+        WHERE {destination_tables['parent']}.casrec_mapping_file_name = '{json_files['parent']}'
         GROUP BY {destination_tables['parent']}_id, {destination_tables['parent']}.{merge_columns['transformed']}
     """
 
@@ -51,27 +53,6 @@ def case_person_caseitem(test_config):
     }
 
     return module_name, source_query, transformed_query, merge_columns, match_columns
-
-
-# @case(tags="row_count")
-# def case_person_count(test_config):
-#     # not every person is linked to a case, commented out because xfail
-#     doesn't work with pytest_cases
-#
-#     config = test_config
-#     source_query = f"""
-#         SELECT
-#             *
-#         FROM {config.schemas['post_transform']}.{destination_tables['parent']}
-#     """
-#
-#     transformed_query = f"""
-#         SELECT
-#             distinct person_id
-#         FROM {config.schemas['post_transform']}.{destination_tables['join_table']}
-#     """
-#
-#     return (source_query, transformed_query, module_name)
 
 
 @case(tags="row_count")
@@ -86,7 +67,7 @@ def case_cases_count(test_config):
 
     transformed_query = f"""
         SELECT
-            distinct case_id
+            distinct caseitem_id
         FROM {config.schemas['post_transform']}.{destination_tables['join_table']}
     """
 

--- a/migration_steps/transform_casrec/app/data_tests/clients/cases_clients_addresses.py
+++ b/migration_steps/transform_casrec/app/data_tests/clients/cases_clients_addresses.py
@@ -141,6 +141,7 @@ def case_clients_5(test_config):
     fk_child_col = [f'"{k}"' for k in join_columns.keys()]
 
     parent_table = [y for x in join_columns.values() for y in x]
+    parent_module_name = "client_persons_mapping"
 
     fk_parent_col = [f'"{y}"' for x in join_columns.values() for y in x.values()]
 
@@ -156,7 +157,7 @@ def case_clients_5(test_config):
                 "{merge_columns['fk_parent']}",
                 {', '.join(fk_parent_col)}
             FROM {config.schemas['post_transform']}.{parent_table[0]}
-            {destination_condition}
+            WHERE casrec_mapping_file_name = '{parent_module_name}'
         """
 
     return (join_columns, merge_columns, fk_child_query, fk_parent_query, module_name)

--- a/migration_steps/transform_casrec/app/data_tests/clients/cases_clients_persons.py
+++ b/migration_steps/transform_casrec/app/data_tests/clients/cases_clients_persons.py
@@ -3,10 +3,10 @@ import pytest
 from pytest_cases import case
 
 
-module_name = "client_persons"
+module_name = "client_persons_mapping"
 source_table = "pat"
 destination_table = "persons"
-destination_condition = "WHERE type = 'actor_client'"
+destination_condition = f"WHERE casrec_mapping_file_name = '{module_name}'"
 
 
 @case(tags="simple")

--- a/migration_steps/transform_casrec/app/data_tests/clients/cases_clients_phonenumbers.py
+++ b/migration_steps/transform_casrec/app/data_tests/clients/cases_clients_phonenumbers.py
@@ -79,8 +79,7 @@ def case_clients_phonenos_3(test_config):
     return (calculated_fields, source_query, module_name)
 
 
-# @case(tags="one_to_one_joins")
-@pytest.mark.skip(reason="can only test by joining it to persons, so not a good test")
+@case(tags="one_to_one_joins")
 def case_clients_phonenos_joins(test_config):
     join_columns = {
         "person_id": {"persons": "id"},
@@ -92,6 +91,7 @@ def case_clients_phonenos_joins(test_config):
     fk_child_col = [f'"{k}"' for k in join_columns.keys()]
 
     parent_table = [y for x in join_columns.values() for y in x]
+    parent_module_name = "client_persons_mapping"
 
     fk_parent_col = [f'"{y}"' for x in join_columns.values() for y in x.values()]
 
@@ -100,6 +100,7 @@ def case_clients_phonenos_joins(test_config):
             "{merge_columns['fk_child']}",
             {', '.join(fk_child_col)}
         FROM {config.schemas['post_transform']}.{destination_table}
+        WHERE casrec_mapping_file_name = '{module_name}'
 
     """
 
@@ -108,6 +109,7 @@ def case_clients_phonenos_joins(test_config):
                 "{merge_columns['fk_parent']}",
                 {', '.join(fk_parent_col)}
             FROM {config.schemas['post_transform']}.{parent_table[0]}
+            WHERE casrec_mapping_file_name = '{parent_module_name}'
         """
 
     return (join_columns, merge_columns, fk_child_query, fk_parent_query, module_name)

--- a/migration_steps/transform_casrec/app/data_tests/conftest.py
+++ b/migration_steps/transform_casrec/app/data_tests/conftest.py
@@ -14,7 +14,11 @@ from data_tests.clients import (
     cases_clients_addresses,
     cases_clients_phonenumbers,
 )
-from data_tests.deputies import cases_deputies_persons
+from data_tests.deputies import (
+    cases_deputies_persons,
+    cases_deputy_phonenumbers_daytime,
+    cases_deputy_phonenumbers_evening,
+)
 from data_tests.supervision_level import cases_supervision_level_log
 
 # from run_data_tests import config
@@ -30,8 +34,11 @@ list_of_test_cases = [
     cases_clients_addresses,
     cases_clients_phonenumbers,
     cases_cases,
+    # cases_person_caseitem,
     cases_supervision_level_log,
     cases_deputies_persons,
+    cases_deputy_phonenumbers_daytime,
+    cases_deputy_phonenumbers_evening,
 ]
 
 

--- a/migration_steps/transform_casrec/app/data_tests/conftest.py
+++ b/migration_steps/transform_casrec/app/data_tests/conftest.py
@@ -34,7 +34,7 @@ list_of_test_cases = [
     cases_clients_addresses,
     cases_clients_phonenumbers,
     cases_cases,
-    # cases_person_caseitem,
+    cases_person_caseitem,
     cases_supervision_level_log,
     cases_deputies_persons,
     cases_deputy_phonenumbers_daytime,

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputies_persons.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputies_persons.py
@@ -3,10 +3,9 @@ import pytest
 from pytest_cases import case
 
 
-module_name = "client_persons"
+module_name = "deputy_persons_mapping"
 source_table = "deputy"
 destination_table = "persons"
-destination_condition = "WHERE type = 'actor_deputy'"
 
 
 @case(tags="simple")
@@ -37,7 +36,7 @@ def case_deputies_1(test_config):
             {merge_columns['transformed']},
             {', '.join(transformed_columns)}
         FROM {config.schemas['post_transform']}.{destination_table}
-        {destination_condition}
+        WHERE casrec_mapping_file_name = '{module_name}'
     """
 
     return (simple_matches, merge_columns, source_query, transformed_query, module_name)
@@ -66,21 +65,21 @@ def case_deputies_2(test_config):
         SELECT
             {', '.join(source_columns)}
         FROM {config.schemas['post_transform']}.{destination_table}
-        {destination_condition}
+        WHERE casrec_mapping_file_name = '{module_name}'
     """
 
     return (defaults, source_query, module_name)
 
 
-@case(tags="lookups")
+# @case(tags="lookups")
 # title is commented out because the anon data is wrong so it will never pass
 def case_deputies_3(test_config):
 
     lookup_fields = {
         # "salutation": {"Title": "title_codes_lookup"},
-        "correspondencebyemail": {
-            "By Email": "Corres_Indicator_lookup"
-        },  # lookup needs null value
+        # "correspondencebyemail": {
+        #     "By Email": "Corres_Indicator_lookup"
+        # },  # lookup needs null value
         # "correspondencebywelsh": {"Welsh": "Welsh_indicator_lookup"} # lookup currently doesn't exist
     }
     merge_columns = {"source": "Email", "transformed": "email"}
@@ -102,7 +101,7 @@ def case_deputies_3(test_config):
             {merge_columns['transformed']},
             {', '.join(transformed_columns)}
         FROM {config.schemas['post_transform']}.{destination_table}
-        {destination_condition}
+        WHERE casrec_mapping_file_name = '{module_name}'
     """
 
     return (lookup_fields, merge_columns, source_query, transformed_query, module_name)
@@ -125,7 +124,7 @@ def case_deputies_4(test_config):
         SELECT
             {', '.join(source_columns)}
         FROM {config.schemas['post_transform']}.persons
-        {destination_condition}
+        WHERE casrec_mapping_file_name = '{module_name}'
     """
 
     return (calculated_fields, source_query, module_name)
@@ -145,7 +144,7 @@ def case_deputies_count(test_config):
         SELECT
             *
         FROM {config.schemas['post_transform']}.{destination_table}
-        {destination_condition}
+        WHERE casrec_mapping_file_name = '{module_name}'
     """
 
     return (source_query, transformed_query, module_name)

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputy_phonenumbers_daytime.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputy_phonenumbers_daytime.py
@@ -80,18 +80,19 @@ def case_deputies_phonenos_daytime_3(test_config):
     return (calculated_fields, source_query, module_name)
 
 
-# @case(tags="one_to_one_joins")
+@case(tags="one_to_one_joins")
 def case_deputies_phonenos_daytime_joins(test_config):
     join_columns = {
         "person_id": {"persons": "id"},
     }
-    merge_columns = {"fk_child": "c_case", "fk_parent": "email"}
+    merge_columns = {"fk_child": "c_email", "fk_parent": "email"}
 
     config = test_config
 
     fk_child_col = [f'"{k}"' for k in join_columns.keys()]
 
     parent_table = [y for x in join_columns.values() for y in x]
+    parent_module_name = "deputy_persons_mapping"
 
     fk_parent_col = [f'"{y}"' for x in join_columns.values() for y in x.values()]
 
@@ -100,6 +101,8 @@ def case_deputies_phonenos_daytime_joins(test_config):
             "{merge_columns['fk_child']}",
             {', '.join(fk_child_col)}
         FROM {config.schemas['post_transform']}.{destination_table}
+        WHERE casrec_mapping_file_name = '{module_name}'
+
     """
 
     fk_parent_query = f"""
@@ -107,6 +110,7 @@ def case_deputies_phonenos_daytime_joins(test_config):
                 "{merge_columns['fk_parent']}",
                 {', '.join(fk_parent_col)}
             FROM {config.schemas['post_transform']}.{parent_table[0]}
+            WHERE casrec_mapping_file_name = '{parent_module_name}'
         """
 
     return (join_columns, merge_columns, fk_child_query, fk_parent_query, module_name)

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputy_phonenumbers_daytime.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputy_phonenumbers_daytime.py
@@ -1,20 +1,19 @@
 from datetime import datetime
 
-import pytest
 from pytest_cases import case
 import pandas as pd
 
-module_name = "client_phonenumbers_mapping"
-source_table = "pat"
+module_name = "deputy_daytime_phonenumbers_mapping"
+source_table = "deputy"
 destination_table = "phonenumbers"
 
 
 @case(tags="simple")
-def case_clients_phonenos_1(test_config):
+def case_deputies_phonenos_daytime_1(test_config):
     simple_matches = {
-        "Client Phone": ["phone_number"],
+        "Contact Telephone": ["phone_number"],
     }
-    merge_columns = {"source": "Case", "transformed": "caserecnumber"}
+    merge_columns = {"source": "Email", "transformed": "c_email"}
 
     config = test_config
 
@@ -40,10 +39,11 @@ def case_clients_phonenos_1(test_config):
 
 
 @case(tags="default")
-def case_clients_phonenos_2(test_config):
+def case_deputies_phonenos_daytime_2(test_config):
     defaults = {
-        "type": "Home",
+        "type": "Work",
         "is_default": False,
+        # "updateddate": "Todays Date",
     }
 
     config = test_config
@@ -55,11 +55,12 @@ def case_clients_phonenos_2(test_config):
         FROM {config.schemas['post_transform']}.{destination_table}
         WHERE casrec_mapping_file_name = '{module_name}'
     """
+
     return (defaults, source_query, module_name)
 
 
 @case(tags="calculated")
-def case_clients_phonenos_3(test_config):
+def case_deputies_phonenos_daytime_3(test_config):
     today = pd.Timestamp.today()
 
     calculated_fields = {
@@ -80,12 +81,11 @@ def case_clients_phonenos_3(test_config):
 
 
 # @case(tags="one_to_one_joins")
-@pytest.mark.skip(reason="can only test by joining it to persons, so not a good test")
-def case_clients_phonenos_joins(test_config):
+def case_deputies_phonenos_daytime_joins(test_config):
     join_columns = {
         "person_id": {"persons": "id"},
     }
-    merge_columns = {"fk_child": "c_case", "fk_parent": "caserecnumber"}
+    merge_columns = {"fk_child": "c_case", "fk_parent": "email"}
 
     config = test_config
 
@@ -100,7 +100,6 @@ def case_clients_phonenos_joins(test_config):
             "{merge_columns['fk_child']}",
             {', '.join(fk_child_col)}
         FROM {config.schemas['post_transform']}.{destination_table}
-
     """
 
     fk_parent_query = f"""
@@ -114,13 +113,14 @@ def case_clients_phonenos_joins(test_config):
 
 
 @case(tags="row_count")
-def case_phonenumbers_count(test_config):
+def case_phonenumbers_daytime_count(test_config):
 
     config = test_config
     source_query = f"""
         SELECT
             *
         FROM {config.schemas['pre_transform']}.{source_table}
+
     """
 
     transformed_query = f"""

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputy_phonenumbers_evening.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_deputy_phonenumbers_evening.py
@@ -80,18 +80,19 @@ def case_deputies_phonenos_evening_3(test_config):
     return (calculated_fields, source_query, module_name)
 
 
-# @case(tags="one_to_one_joins")
+@case(tags="one_to_one_joins")
 def case_deputies_phonenos_evening_joins(test_config):
     join_columns = {
         "person_id": {"persons": "id"},
     }
-    merge_columns = {"fk_child": "c_case", "fk_parent": "caserecnumber"}
+    merge_columns = {"fk_child": "c_email", "fk_parent": "email"}
 
     config = test_config
 
     fk_child_col = [f'"{k}"' for k in join_columns.keys()]
 
     parent_table = [y for x in join_columns.values() for y in x]
+    parent_module_name = "deputy_persons_mapping"
 
     fk_parent_col = [f'"{y}"' for x in join_columns.values() for y in x.values()]
 
@@ -100,6 +101,7 @@ def case_deputies_phonenos_evening_joins(test_config):
             "{merge_columns['fk_child']}",
             {', '.join(fk_child_col)}
         FROM {config.schemas['post_transform']}.{destination_table}
+        WHERE casrec_mapping_file_name = '{module_name}'
     """
 
     fk_parent_query = f"""
@@ -107,6 +109,7 @@ def case_deputies_phonenos_evening_joins(test_config):
                 "{merge_columns['fk_parent']}",
                 {', '.join(fk_parent_col)}
             FROM {config.schemas['post_transform']}.{parent_table[0]}
+            WHERE casrec_mapping_file_name = '{parent_module_name}'
         """
 
     return (join_columns, merge_columns, fk_child_query, fk_parent_query, module_name)

--- a/migration_steps/transform_casrec/app/data_tests/test_complex_joins.py
+++ b/migration_steps/transform_casrec/app/data_tests/test_complex_joins.py
@@ -23,7 +23,7 @@ log = logging.getLogger("root")
     cases=list_of_test_cases,
     has_tag="many_to_one_join",
 )
-@pytest.mark.skip(reason="removed joins")
+# @pytest.mark.skip(reason="removed joins")
 def test_complex_joins(
     test_config,
     module_name,

--- a/migration_steps/transform_casrec/app/data_tests/test_simple_joins.py
+++ b/migration_steps/transform_casrec/app/data_tests/test_simple_joins.py
@@ -25,7 +25,7 @@ log = logging.getLogger("root")
     cases=list_of_test_cases,
     has_tag="one_to_one_joins",
 )
-@pytest.mark.skip(reason="moving to its own test")
+# @pytest.mark.skip(reason="moving to its own test")
 def test_one_to_one_joins(
     test_config,
     join_columns,
@@ -58,6 +58,7 @@ def test_one_to_one_joins(
         sort_col=merge_columns["fk_parent"],
         sample=False,
     )
+    print(fk_parent_query)
     fk_parent_sample_df = fk_parent_df[
         fk_parent_df[merge_columns["fk_parent"]].isin(sample_caserefs)
     ]
@@ -70,11 +71,11 @@ def test_one_to_one_joins(
     ].tolist()
     fk_parent_id_list = [int(x) for x in fk_parent_id_list]
 
-    log.debug(
+    print(
         f"Checking {fk_parent_df.shape[0]} rows of data ({config.SAMPLE_PERCENTAGE}%) from table: {module_name} "
     )
     success = set(fk_child_id_list) == set(fk_parent_id_list)
-    log.log(
+    print(
         config.VERBOSE,
         f"checking {[k for k in join_columns][0]} == "
         f"{[y for x in join_columns.values() for y in x.values()][0]}.... "

--- a/migration_steps/transform_casrec/app/data_tests/test_simple_joins.py
+++ b/migration_steps/transform_casrec/app/data_tests/test_simple_joins.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_cases import parametrize_with_cases
 
 from data_tests.conftest import (
@@ -24,6 +25,7 @@ log = logging.getLogger("root")
     cases=list_of_test_cases,
     has_tag="one_to_one_joins",
 )
+@pytest.mark.skip(reason="moving to its own test")
 def test_one_to_one_joins(
     test_config,
     join_columns,

--- a/migration_steps/transform_casrec/app/entities/deputies/__init__.py
+++ b/migration_steps/transform_casrec/app/entities/deputies/__init__.py
@@ -4,16 +4,19 @@ import logging
 from entities.deputies.persons import insert_persons_deputies
 from helpers import log_title
 
+from entities.deputies.phonenumbers_daytime import insert_phonenumbers_deputies_daytime
+from entities.deputies.phonenumbers_evening import insert_phonenumbers_deputies_evening
+
 log = logging.getLogger("root")
 
 
 def runner(target_db, db_config):
     """
-    | Name      | Running Order | Requires |
-    | --------- | ------------- | -------- |
-    | persons   | 1             |          |
-    | addresses | 2             | persons  |
-    |           |               |          |
+    | Name          | Running Order | Requires |
+    | ---------     | ------------- | -------- |
+    | persons       | 1             |          |
+    | phonenumbers  | 2             | persons  |
+    |               |               |          |
 
     """
 
@@ -21,6 +24,10 @@ def runner(target_db, db_config):
 
     log.debug("insert_persons_deputies")
     insert_persons_deputies(target_db=target_db, db_config=db_config)
+
+    log.debug("insert_phonenumbers_deputies")
+    insert_phonenumbers_deputies_daytime(target_db=target_db, db_config=db_config)
+    insert_phonenumbers_deputies_evening(target_db=target_db, db_config=db_config)
 
     # log.debug("insert_addresses_deputies")
     # insert_addresses_deputies(target_db=target_db, db_config=db_config)

--- a/migration_steps/transform_casrec/app/entities/deputies/phonenumbers_daytime.py
+++ b/migration_steps/transform_casrec/app/entities/deputies/phonenumbers_daytime.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from utilities.basic_data_table import get_basic_data_table
+
+definition = {
+    "source_table_name": "deputy",
+    "source_table_additional_columns": ["Email"],
+    "destination_table_name": "phonenumbers",
+}
+
+mapping_file_name = "deputy_daytime_phonenumbers_mapping"
+
+
+def insert_phonenumbers_deputies_daytime(db_config, target_db):
+
+    sirius_details, phonenos_df = get_basic_data_table(
+        db_config=db_config,
+        mapping_file_name=mapping_file_name,
+        table_definition=definition,
+    )
+
+    persons_query = (
+        f'select "id", "email" from {db_config["target_schema"]}.persons '
+        f"where \"type\" = 'actor_deputy';"
+    )
+    persons_df = pd.read_sql_query(persons_query, db_config["db_connection_string"])
+
+    persons_df = persons_df[["id", "email"]]
+
+    phonenos_joined_df = phonenos_df.merge(
+        persons_df, how="left", left_on="c_email", right_on="email"
+    )
+
+    phonenos_joined_df["person_id"] = phonenos_joined_df["id_y"]
+    phonenos_joined_df = phonenos_joined_df.drop(columns=["id_y", "email"])
+    phonenos_joined_df = phonenos_joined_df.rename(columns={"id_x": "id"})
+
+    target_db.insert_data(
+        table_name=definition["destination_table_name"],
+        df=phonenos_joined_df,
+        sirius_details=sirius_details,
+    )

--- a/migration_steps/transform_casrec/app/entities/deputies/phonenumbers_evening.py
+++ b/migration_steps/transform_casrec/app/entities/deputies/phonenumbers_evening.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from utilities.basic_data_table import get_basic_data_table
+
+definition = {
+    "source_table_name": "deputy",
+    "source_table_additional_columns": ["Email"],
+    "destination_table_name": "phonenumbers",
+}
+
+mapping_file_name = "deputy_evening_phonenumbers_mapping"
+
+
+def insert_phonenumbers_deputies_evening(db_config, target_db):
+
+    sirius_details, phonenos_df = get_basic_data_table(
+        db_config=db_config,
+        mapping_file_name=mapping_file_name,
+        table_definition=definition,
+    )
+
+    persons_query = (
+        f'select "id", "email" from {db_config["target_schema"]}.persons '
+        f"where \"type\" = 'actor_deputy';"
+    )
+    persons_df = pd.read_sql_query(persons_query, db_config["db_connection_string"])
+
+    persons_df = persons_df[["id", "email"]]
+
+    phonenos_joined_df = phonenos_df.merge(
+        persons_df, how="left", left_on="c_email", right_on="email"
+    )
+
+    phonenos_joined_df["person_id"] = phonenos_joined_df["id_y"]
+    phonenos_joined_df = phonenos_joined_df.drop(columns=["id_y", "email"])
+    phonenos_joined_df = phonenos_joined_df.rename(columns={"id_x": "id"})
+
+    target_db.insert_data(
+        table_name=definition["destination_table_name"],
+        df=phonenos_joined_df,
+        sirius_details=sirius_details,
+    )

--- a/migration_steps/transform_casrec/app/utilities/basic_data_table.py
+++ b/migration_steps/transform_casrec/app/utilities/basic_data_table.py
@@ -46,7 +46,7 @@ def get_basic_data_table(mapping_file_name, table_definition, db_config):
         sql=source_data_query, con=db_config["db_connection_string"]
     )
 
-    persons_df = transform.perform_transformations(
+    result_df = transform.perform_transformations(
         mapping_definitions=mapping_dict,
         table_definition=table_definition,
         source_data_df=source_data_df,
@@ -55,4 +55,6 @@ def get_basic_data_table(mapping_file_name, table_definition, db_config):
         sirius_details=sirius_details,
     )
 
-    return sirius_details, persons_df
+    result_df["casrec_mapping_file_name"] = mapping_file_name
+
+    return sirius_details, result_df


### PR DESCRIPTION
Took this opportunity to sort out some of the data tests in `transform`. These are only useful when actually adding new entities to the step so do not run in the main pipeline. But still good to have them back.

No changes to any subsequent steps as phone numbers already reindexed etc from clients, so got all that for free.