### PR TITLE
In 625 order deputy extra bits

### DIFF
--- a/migration_steps/shared/mapping_definitions/lookups/deputy_status_lookup.json
+++ b/migration_steps/shared/mapping_definitions/lookups/deputy_status_lookup.json
@@ -3,7 +3,7 @@
         "sirius_mapping": "ACTIVE"
     },
     "1": {
-        "sirius_mapping": "ACTIVE"
+        "sirius_mapping": "DISCHARGED"
     },
     "88": {
         "sirius_mapping": "ACTIVE"

--- a/migration_steps/shared/mapping_definitions/lookups/discharge_lookup.json
+++ b/migration_steps/shared/mapping_definitions/lookups/discharge_lookup.json
@@ -1,0 +1,5 @@
+{
+    "99": {
+        "sirius_mapping": "Disch Date"
+    }
+}

--- a/migration_steps/shared/mapping_definitions/lookups/discharge_lookup.json
+++ b/migration_steps/shared/mapping_definitions/lookups/discharge_lookup.json
@@ -1,5 +1,0 @@
-{
-    "99": {
-        "sirius_mapping": "Disch Date"
-    }
-}

--- a/migration_steps/shared/mapping_definitions/order_deputy_mapping.json
+++ b/migration_steps/shared/mapping_definitions/order_deputy_mapping.json
@@ -202,8 +202,8 @@
             "casrec_table": "deputy",
             "casrec_column_name": "Disch Death",
             "alias": "Disch Death",
-            "requires_transformation": "",
-            "lookup_table": "",
+            "requires_transformation": "conditional_lookup",
+            "lookup_table": "discharge_date_lookup",
             "default_value": "",
             "calculated": "",
             "additional_columns": "Stat"

--- a/migration_steps/transform_casrec/app/data_tests/conftest.py
+++ b/migration_steps/transform_casrec/app/data_tests/conftest.py
@@ -18,6 +18,7 @@ from data_tests.deputies import (
     cases_deputies_persons,
     cases_deputy_phonenumbers_daytime,
     cases_deputy_phonenumbers_evening,
+    cases_order_deputy,
 )
 from data_tests.supervision_level import cases_supervision_level_log
 
@@ -37,6 +38,7 @@ list_of_test_cases = [
     cases_person_caseitem,
     cases_supervision_level_log,
     cases_deputies_persons,
+    cases_order_deputy,
     cases_deputy_phonenumbers_daytime,
     cases_deputy_phonenumbers_evening,
 ]

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_order_deputy.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_order_deputy.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from pandas.core.common import flatten
 from pytest_cases import case
 
 
@@ -20,6 +21,54 @@ def case_order_deputies_lookups(test_config):
     config = test_config
 
     source_columns = [f'"{y}"' for x in lookup_fields.values() for y in x]
+    transformed_columns = [f'"{x}"' for x in lookup_fields.keys()]
+
+    source_query = f"""
+        SELECT
+            "{merge_columns['source']}",
+            {', '.join(source_columns)}
+        FROM {config.schemas['pre_transform']}.{source_table}
+
+    """
+
+    transformed_query = f"""
+        SELECT
+            {merge_columns['transformed']},
+            {', '.join(transformed_columns)}
+        FROM {config.schemas['post_transform']}.{destination_table}
+        WHERE casrec_mapping_file_name = '{module_name}'
+    """
+
+    return (lookup_fields, merge_columns, source_query, transformed_query, module_name)
+
+
+@case(tags="conditional_lookup")
+def case_order_deputies_con_lookups(test_config):
+
+    lookup_fields = {
+        "statuschangedate": {
+            "cols": {
+                "result": "Disch Death",
+                "reference": "Stat",
+            },
+            "lookup_def": "discharge_lookup",
+        }
+    }
+    merge_columns = {"source": "Deputy No", "transformed": "c_deputy_no"}
+
+    config = test_config
+
+    source_columns = [
+        f'"{x}"'
+        for x in flatten(
+            [
+                list(z.values())
+                for x in lookup_fields.values()
+                for y, z in x.items()
+                if y == "cols"
+            ]
+        )
+    ]
     transformed_columns = [f'"{x}"' for x in lookup_fields.keys()]
 
     source_query = f"""

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_order_deputy.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_order_deputy.py
@@ -51,7 +51,7 @@ def case_order_deputies_con_lookups(test_config):
                 "result": "Disch Death",
                 "reference": "Stat",
             },
-            "lookup_def": "discharge_lookup",
+            "lookup_def": "discharge_date_lookup",
         }
     }
     merge_columns = {"source": "Deputy No", "transformed": "c_deputy_no"}

--- a/migration_steps/transform_casrec/app/data_tests/deputies/cases_order_deputy.py
+++ b/migration_steps/transform_casrec/app/data_tests/deputies/cases_order_deputy.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import pytest
+from pytest_cases import case
+
+
+module_name = "order_deputy_mapping"
+source_table = "deputy"
+destination_table = "order_deputy"
+
+
+@case(tags="lookups")
+def case_order_deputies_lookups(test_config):
+
+    lookup_fields = {
+        "statusoncase": {"Stat": "deputy_status_lookup"},
+        "relationshiptoclient": {"Dep Type": "deputy_relationship_lookup"},
+    }
+    merge_columns = {"source": "Deputy No", "transformed": "c_deputy_no"}
+
+    config = test_config
+
+    source_columns = [f'"{y}"' for x in lookup_fields.values() for y in x]
+    transformed_columns = [f'"{x}"' for x in lookup_fields.keys()]
+
+    source_query = f"""
+        SELECT
+            "{merge_columns['source']}",
+            {', '.join(source_columns)}
+        FROM {config.schemas['pre_transform']}.{source_table}
+
+    """
+
+    transformed_query = f"""
+        SELECT
+            {merge_columns['transformed']},
+            {', '.join(transformed_columns)}
+        FROM {config.schemas['post_transform']}.{destination_table}
+        WHERE casrec_mapping_file_name = '{module_name}'
+    """
+
+    return (lookup_fields, merge_columns, source_query, transformed_query, module_name)
+
+
+#  is this even possible?
+#
+# @case(tags="row_count")
+# def case_order_deputies_count(test_config):
+#
+#     config = test_config
+#     source_query = f"""
+#         SELECT
+#             *
+#         FROM {config.schemas['pre_transform']}.{source_table}
+#     """
+#
+#     transformed_query = f"""
+#         SELECT
+#             *
+#         FROM {config.schemas['post_transform']}.{destination_table}
+#         WHERE casrec_mapping_file_name = '{module_name}'
+#     """
+#
+#     return (source_query, transformed_query, module_name)

--- a/migration_steps/transform_casrec/app/data_tests/test_conditional_lookup.py
+++ b/migration_steps/transform_casrec/app/data_tests/test_conditional_lookup.py
@@ -1,0 +1,113 @@
+import re
+
+from pytest_cases import parametrize_with_cases
+
+from data_tests.conftest import (
+    list_of_test_cases,
+    add_to_tested_list,
+)
+from data_tests.helpers import (
+    get_data_from_query,
+    get_merge_col_data_as_list,
+    merge_source_and_transformed_df,
+)
+import logging
+
+
+from helpers import get_lookup_dict
+from datetime import datetime
+
+log = logging.getLogger("root")
+
+
+@parametrize_with_cases(
+    (
+        "lookup_fields",
+        "merge_columns",
+        "source_query",
+        "transformed_query",
+        "module_name",
+    ),
+    cases=list_of_test_cases,
+    has_tag="conditional_lookup",
+)
+def test_map_conditional_lookup_tables(
+    test_config,
+    lookup_fields,
+    merge_columns,
+    source_query,
+    transformed_query,
+    module_name,
+):
+    print(f"module_name: {module_name}")
+
+    add_to_tested_list(
+        module_name=module_name,
+        tested_fields=[x for x in lookup_fields.keys()]
+        + [merge_columns["transformed"]],
+    )
+
+    config = test_config
+
+    source_sample_df = get_data_from_query(
+        query=source_query, config=config, sort_col=merge_columns["source"], sample=True
+    )
+
+    assert source_sample_df.shape[0] > 0
+
+    sample_caserefs = get_merge_col_data_as_list(
+        df=source_sample_df, column_name=merge_columns["source"]
+    )
+
+    transformed_df = get_data_from_query(
+        query=transformed_query,
+        config=config,
+        sort_col=merge_columns["transformed"],
+        sample=False,
+    )
+
+    assert transformed_df.shape[0] > 0
+
+    transformed_sample_df = transformed_df[
+        transformed_df[merge_columns["transformed"]].isin(sample_caserefs)
+    ]
+
+    result_df = merge_source_and_transformed_df(
+        source_df=source_sample_df,
+        transformed_df=transformed_sample_df,
+        merge_columns=merge_columns,
+    )
+
+    log.debug(
+        f"Checking {result_df.shape[0]} rows of data ({config.SAMPLE_PERCENTAGE}%) from table: {module_name} "
+    )
+
+    assert result_df.shape[0] > 0
+    for k, v in lookup_fields.items():
+        lookup_filename = lookup_fields[k]["lookup_def"]
+
+        for i, j in v.items():
+            result_col = lookup_fields[k]["cols"]["result"]
+
+            reference_col = lookup_fields[k]["cols"]["reference"]
+
+            lookup_dict = get_lookup_dict(file_name=lookup_filename.lower())
+
+            result_df["mapped"] = result_df[reference_col].map(lookup_dict)
+
+            result_df = result_df.loc[result_df["mapped"].notnull()]
+
+            result_df[result_col] = result_df[result_col].apply(lambda x: f"{x}")
+            result_df[k] = result_df[k].apply(lambda x: f"{x}")
+
+            assert result_df[result_col].fillna("").equals(result_df[k].fillna(""))
+
+            match = result_df[result_col].fillna("").equals(result_df[k].fillna(""))
+
+            print(
+                f"checking {k} == {result_col}...."
+                f""
+                f" {'OK' if match is True else 'oh no'} ",
+            )
+
+            assert match is True

--- a/migration_steps/transform_casrec/app/data_tests/test_lookup_tables.py
+++ b/migration_steps/transform_casrec/app/data_tests/test_lookup_tables.py
@@ -36,7 +36,8 @@ def test_map_lookup_tables(
     transformed_query,
     module_name,
 ):
-    log.debug(f"module_name: {module_name}")
+    print(f"module_name: {module_name}")
+
     add_to_tested_list(
         module_name=module_name,
         tested_fields=[x for x in lookup_fields.keys()]

--- a/migration_steps/transform_casrec/app/entities/deputies/order_deputy.py
+++ b/migration_steps/transform_casrec/app/entities/deputies/order_deputy.py
@@ -13,15 +13,31 @@ mapping_file_name = "order_deputy_mapping"
 
 def insert_order_deputies(db_config, target_db):
 
-    sirius_details, orig_person_df = get_basic_data_table(
+    # Get the standard data from casrec 'deputy' table
+    sirius_details, person_df = get_basic_data_table(
         db_config=db_config,
         mapping_file_name=mapping_file_name,
         table_definition=definition,
     )
 
-    person_query = f"""select * from {db_config['target_schema']}.persons where type='actor_deputy'"""
-    person_df = pd.read_sql_query(person_query, db_config["db_connection_string"])
+    # Get ids of deputies that have already been transformed
+    existing_deputies_query = f"""
+        select c_deputy_no, id from {db_config['target_schema']}.persons where casrec_mapping_file_name = 'deputy_persons_mapping';
+    """
+    existing_deputies_df = pd.read_sql_query(
+        existing_deputies_query, db_config["db_connection_string"]
+    )
 
+    # use the id of the existing deputy
+    existing_deputies_merged_df = person_df.merge(
+        existing_deputies_df, how="left", left_on="c_deputy_no", right_on="c_deputy_no"
+    )
+    existing_deputies_merged_df = existing_deputies_merged_df.rename(
+        columns={"id_y": "id"}
+    )
+    deputies_df = existing_deputies_merged_df.drop(columns=["id_x"])
+
+    # deputyship
     deputyship_query = f"""select "Deputy No", "CoP Case" from {db_config["source_schema"]}.deputyship;"""
     deputyship_df = pd.read_sql_query(
         deputyship_query, db_config["db_connection_string"]
@@ -33,7 +49,7 @@ def insert_order_deputies(db_config, target_db):
     order_df = pd.read_sql_query(order_query, db_config["db_connection_string"])
 
     deputyship_persons_joined_df = deputyship_df.merge(
-        person_df, how="left", left_on="Deputy No", right_on="c_deputy_no"
+        deputies_df, how="left", left_on="Deputy No", right_on="c_deputy_no"
     )
     deputyship_persons_joined_df["deputy_id"] = deputyship_persons_joined_df["id"]
     deputyship_persons_joined_df["deputy_id"] = deputyship_persons_joined_df[

--- a/migration_steps/transform_casrec/app/transform_data/conditional_lookups.py
+++ b/migration_steps/transform_casrec/app/transform_data/conditional_lookups.py
@@ -20,7 +20,7 @@ def conditional_lookup(
     lookup_file_name: str,
     df: pd.DataFrame,
 ) -> pd.DataFrame:
-    log.info(f"Doing condiction lookup on {lookup_col} in file {lookup_file_name}")
+    log.info(f"Doing conditional lookup on {lookup_col} in file {lookup_file_name}")
     log.log(
         config.DATA,
         f"before\n{df.sample(n=config.row_limit).to_markdown()}",


### PR DESCRIPTION
* small mapping def changes (see [related pr](https://github.com/ministryofjustice/opg-data-casrec-migration-mappings/pull/22))
* changed `order_deputy` to use only the columns it actually needs (was previously using the whole `persons` table) and joined it up with the existing ids
* test for conditional lookups
* changed that typo for you @jamesrwarren 