### PR TITLE
schema problems

### DIFF
--- a/migration_steps/integration/business_rules/app/app.py
+++ b/migration_steps/integration/business_rules/app/app.py
@@ -45,11 +45,7 @@ db_config = {
     "target_schema": config.schemas["integration"],
     "sirius_schema": config.schemas["public"],
 }
-target_db_engine = create_engine(
-    db_config["db_connection_string"],
-    execution_options=dict(stream_results=True),
-    server_side_cursors=True,
-)
+target_db_engine = create_engine(db_config["db_connection_string"])
 
 
 @click.command()

--- a/migration_steps/integration/integration.sh
+++ b/migration_steps/integration/integration.sh
@@ -2,7 +2,7 @@
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-python3 "${DIR}/schema_setup/app/app.py"
+#python3 "${DIR}/schema_setup/app/app.py"
 #python3 "${DIR}/fixtures/app/app.py"
 python3 "${DIR}/reindex_ids/app/app.py" -vv --clear=True
 python3 "${DIR}/business_rules/app/app.py" -vv --clear=True

--- a/migration_steps/integration/load_to_staging/app/move.py
+++ b/migration_steps/integration/load_to_staging/app/move.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import logging
 
 import psycopg2
@@ -93,4 +94,4 @@ def generate_inserts(db_config, db_engine, tables):
                 f"There was an error inserting {table} into {db_config['target_schema']}"
             )
             log.debug(e)
-            break
+            sys.exit(1)

--- a/migration_steps/integration/load_to_staging/app/setup.py
+++ b/migration_steps/integration/load_to_staging/app/setup.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import logging
 
 import psycopg2
@@ -35,3 +36,4 @@ def insert_base_data(db_config, db_engine):
                 f"There was an error inserting the {name} data into {db_config['target_schema']}"
             )
             log.debug(e)
+            sys.exit(1)

--- a/migration_steps/integration/reindex_ids/app/app.py
+++ b/migration_steps/integration/reindex_ids/app/app.py
@@ -6,7 +6,7 @@ import time
 import click
 from sqlalchemy import create_engine
 from existing_data.match_existing_data import match_existing_data
-from reindex.move_by_table import move_all_tables
+from reindex.move_by_table import move_all_tables, create_schema
 from reindex.reindex_foreign_keys import update_fks
 from reindex.reindex_primary_keys import update_pks
 from utilities.clear_database import clear_tables
@@ -67,13 +67,21 @@ def main(verbose, clear):
         log.info(f"{verbose} is not a valid verbosity level")
         log.info(f"INFO logging enabled")
 
-    log.info(log_title(message="Integration Step: Merge Casrec data with Sirius data"))
+    log.info(
+        log_title(message="Integration Step: Reindex migrated data based on Sirius ids")
+    )
     log.info(
         log_title(
             message=f"Source: {db_config['source_schema']} Target: {db_config['target_schema']}"
         )
     )
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
+
+    log.info(f"Creating schema '{db_config['target_schema']}' if it doesn't exist")
+    create_schema(
+        target_db_connection=db_config["db_connection_string"],
+        schema_name=db_config["target_schema"],
+    )
 
     if clear:
         clear_tables(db_config)

--- a/migration_steps/integration/reindex_ids/app/reindex/move_by_table.py
+++ b/migration_steps/integration/reindex_ids/app/reindex/move_by_table.py
@@ -27,6 +27,7 @@ def create_schema(target_db_connection, schema_name):
         cursor.execute(statement)
     except Exception as e:
         log.error(e)
+        sys.exit(1)
     finally:
         cursor.close()
         conn.commit()
@@ -44,6 +45,7 @@ def move_all_tables(db_config, table_list):
         cursor.execute(query)
     except Exception as e:
         log.error(e)
+        sys.exit(1)
     finally:
         cursor.close()
         conn.commit()

--- a/migration_steps/integration/reindex_ids/app/reindex/move_by_table.py
+++ b/migration_steps/integration/reindex_ids/app/reindex/move_by_table.py
@@ -14,6 +14,24 @@ sys.path.insert(0, str(current_path) + "/../../../../../shared")
 log = logging.getLogger("root")
 
 
+def create_schema(target_db_connection, schema_name):
+    statement = f"""
+        CREATE SCHEMA IF NOT EXISTS {schema_name};
+    """
+
+    connection_string = target_db_connection
+    conn = psycopg2.connect(connection_string)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(statement)
+    except Exception as e:
+        log.error(e)
+    finally:
+        cursor.close()
+        conn.commit()
+
+
 @timer
 def move_all_tables(db_config, table_list):
     query = generate_create_tables_query(db_config, table_list)
@@ -25,7 +43,7 @@ def move_all_tables(db_config, table_list):
     try:
         cursor.execute(query)
     except Exception as e:
-        print(e)
+        log.error(e)
     finally:
         cursor.close()
         conn.commit()
@@ -42,7 +60,8 @@ def generate_create_tables_query(db_config, table_list):
         select_key_cols = [f"{x} as transformation_schema_{x}" for x in keys]
 
         log.debug(
-            f"Generating CREATE TABLE for {table_name} with extra cols: {', '.join([f'transformation_schema_{x}' for x in keys])}"
+            f"Generating CREATE TABLE for {db_config['target_schema']}.{table_name} "
+            f"with extra cols: {', '.join([f'transformation_schema_{x}' for x in keys])}"
         )
 
         query = f"""

--- a/migration_steps/integration/reindex_ids/app/reindex/reindex_foreign_keys.py
+++ b/migration_steps/integration/reindex_ids/app/reindex/reindex_foreign_keys.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+
 import psycopg2
 
 from decorators import timer
@@ -42,7 +44,8 @@ def update_fks(db_config, table_details):
     try:
         cursor.execute(query)
     except Exception as e:
-        print(e)
+        log.debug(e)
+        sys.exit(1)
     finally:
         cursor.close()
         conn.commit()

--- a/migration_steps/integration/reindex_ids/app/reindex/reindex_primary_keys.py
+++ b/migration_steps/integration/reindex_ids/app/reindex/reindex_primary_keys.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+
 import psycopg2
 
 from decorators import timer
@@ -39,7 +41,8 @@ def get_max_pk_dict(db_connection_string, max_val_query):
             result_dict[i[0]] = {i[1]: i[2] if i[2] else 0}
 
     except Exception as e:
-        print(e)
+        log.debug(e)
+        sys.exit(1)
     finally:
         cursor.close()
         conn.commit()
@@ -80,7 +83,8 @@ def update_pks(db_config, table_details):
     try:
         cursor.execute(update_query)
     except Exception as e:
-        print(e)
+        log.debug(e)
+        sys.exit(1)
     finally:
         cursor.close()
         conn.commit()

--- a/migration_steps/load_to_sirius/app/move.py
+++ b/migration_steps/load_to_sirius/app/move.py
@@ -54,7 +54,7 @@ def get_columns_query(table, schema):
 
 
 def remove_unecessary_columns(columns):
-    unecessary_field_names = ["method"]
+    unecessary_field_names = ["method", "casrec_row_id"]
 
     return [column for column in columns if column not in unecessary_field_names]
 
@@ -101,11 +101,12 @@ def insert_data_into_target(db_config, source_db_engine, target_db_engine, table
     chunk_size = 10000
     offset = 0
     while True:
+
         query = f"""
             SELECT {', '.join(columns)}
             FROM {db_config["source_schema"]}.{table}
             WHERE method = 'INSERT'
-            ORDER BY {pk}
+            ORDER BY {', '.join(pk)}
             LIMIT {chunk_size} OFFSET {offset};
         """
 
@@ -125,13 +126,16 @@ def insert_data_into_target(db_config, source_db_engine, target_db_engine, table
         try:
             target_db_engine.execute(insert_statement)
         except Exception:
+
             log.error(
-                f"There was an error inserting data into {len(data_to_insert)} rows into {db_config['source_schema']}.{table}"
+                f"There was an error inserting  {len(data_to_insert)} rows into {db_config['source_schema']}.{table}"
             )
+
             sys.exit(1)
 
         offset += chunk_size
         log.debug(f"doing offset {offset} for table {table}")
+
         if len(data_to_insert) < chunk_size:
             break
 
@@ -153,7 +157,7 @@ def update_data_in_target(db_config, source_db_engine, table, pk):
         query = f"""
             SELECT {', '.join(columns)} FROM {db_config["source_schema"]}.{table}
             WHERE method = 'UPDATE'
-            ORDER BY {pk}
+            ORDER BY {', '.join(pk)}
             LIMIT {chunk_size} OFFSET {offset};
         """
 

--- a/migration_steps/load_to_sirius/app/move.py
+++ b/migration_steps/load_to_sirius/app/move.py
@@ -106,7 +106,7 @@ def insert_data_into_target(db_config, source_db_engine, target_db_engine, table
             FROM {db_config["source_schema"]}.{table}
             WHERE method = 'INSERT'
             ORDER BY {pk}
-            LIMIT {chunk_size} OFFSET {offset};;
+            LIMIT {chunk_size} OFFSET {offset};
         """
 
         data_to_insert = pd.read_sql_query(
@@ -124,8 +124,11 @@ def insert_data_into_target(db_config, source_db_engine, target_db_engine, table
 
         try:
             target_db_engine.execute(insert_statement)
-        except Exception as e:
-            log.error(e)
+        except Exception:
+            log.error(
+                f"There was an error inserting data into {len(data_to_insert)} rows into {db_config['source_schema']}.{table}"
+            )
+            sys.exit(1)
 
         offset += chunk_size
         log.debug(f"doing offset {offset} for table {table}")

--- a/migration_steps/load_to_sirius/app/reset_sequences.py
+++ b/migration_steps/load_to_sirius/app/reset_sequences.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Dict
 import logging
 
@@ -29,6 +30,7 @@ def reset_sequence(sequence_details, db_config):
         log.error("Error: %s" % error)
         conn.rollback()
         cursor.close()
+        sys.exit(1)
 
 
 def reset_all_uid_sequences(uid_sequence_list, db_config):
@@ -83,3 +85,4 @@ def reset_uid_sequence(sequence_details, db_config):
         log.error("Error: %s" % error)
         conn.rollback()
         cursor.close()
+        sys.exit(1)

--- a/migration_steps/shared/db_helpers.py
+++ b/migration_steps/shared/db_helpers.py
@@ -1,4 +1,6 @@
 import os
+import sys
+
 import psycopg2
 import pandas as pd
 import numpy as np
@@ -141,14 +143,18 @@ def copy_schema(
     with fileinput.FileInput(str(schema_dump), inplace=True) as file:
         for line in file:
             print(
-                line.replace(f'TO {from_config["user"]}', f'TO {to_config["user"]}',),
+                line.replace(
+                    f'TO {from_config["user"]}',
+                    f'TO {to_config["user"]}',
+                ),
                 end="",
             )
     with fileinput.FileInput(str(schema_dump), inplace=True) as file:
         for line in file:
             print(
                 line.replace(
-                    f'Owner: {from_config["user"]}', f'Owner: {to_config["user"]}',
+                    f'Owner: {from_config["user"]}',
+                    f'Owner: {to_config["user"]}',
                 ),
                 end="",
             )
@@ -187,7 +193,7 @@ def execute_sql_file(sql_path, filename, conn, schema="public"):
         print("Error: %s" % error)
         conn.rollback()
         cursor.close()
-        return 1
+        sys.exit(1)
     cursor.close()
 
 
@@ -242,7 +248,7 @@ def execute_insert(conn, df, table):
         print("Error: %s" % error)
         conn.rollback()
         cursor.close()
-        return 1
+        sys.exit(1)
     cursor.close()
 
 

--- a/migration_steps/shared/table_helpers.py
+++ b/migration_steps/shared/table_helpers.py
@@ -83,5 +83,5 @@ def get_pk(engine, schema, table):
         """
     response = engine.execute(get_pk_statement)
     for r in response:
-        primary_key = r.values()[0]
+        primary_key = r.values()
         return primary_key

--- a/migration_steps/transform_casrec/app/utilities/db_insert.py
+++ b/migration_steps/transform_casrec/app/utilities/db_insert.py
@@ -238,6 +238,7 @@ class InsertData:
             self.db_engine.execute(insert_statement)
         except Exception as e:
             log.error(e)
+            sys.exit(1)
 
         inserted_count = len(df)
 


### PR DESCRIPTION
This started with the pipeline surprise failing, and resulted in a whole drama of things.

The initial problem was because for some reason we had `server_side_cursors` on in the `business_rules` step, so I removed that. This has been in for a while so I don't know why it suddenly started causing a problem.

Then the `integration` schema had issues because it kept telling me tables already existed, so I fixed that too by getting rid of the schema create thing (as it's not needed, it creates its own tables on the fly) and adding it into `reindex_ids`.

Then I discovered that inserting into `caseitem_note` on the sirius db was failing but not showing us there was a problem, so I added a load of `sys.exit()` all over where we are inserting/updating databases and we don't expect errors, so now the pipline fails visibly (it has been failing secretly for a while).

So now I am trying to fix the `caseitem_note` problem and I've just noticed the pipeline has failed again, even though it works fine locally. Arg.

