### PR TITLE
In 651 Bonds validation and integrate secondary mapping files

### DIFF
--- a/migration_steps/shared/sql/drop_transformation_functions.sql
+++ b/migration_steps/shared/sql/drop_transformation_functions.sql
@@ -2,5 +2,6 @@
 
 DROP FUNCTION transf_capitalise(source varchar);
 DROP FUNCTION transf_convert_to_bool(source varchar);
+DROP FUNCTION transf_money_poundPence(source character);
 DROP FUNCTION getCasrecAddress(ad1 varchar, ad2 varchar, ad3 varchar, ad4 varchar);
 DROP FUNCTION getSiriusAddress(addressLines anyelement, town varchar, county varchar);

--- a/migration_steps/shared/sql/transformation_functions.sql
+++ b/migration_steps/shared/sql/transformation_functions.sql
@@ -19,6 +19,15 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- money_poundPence
+CREATE OR REPLACE FUNCTION transf_money_poundPence(source character)
+    RETURNS decimal AS $$
+DECLARE
+BEGIN
+    RETURN ROUND(source::numeric, 2);
+END;
+$$ LANGUAGE plpgsql;
+
 
 CREATE OR REPLACE FUNCTION getCasrecAddress(ad1 varchar, ad2 varchar, ad3 varchar, ad4 varchar)
 RETURNS varchar AS $$

--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -9,8 +9,17 @@
             "client_id",
             "feepayer_id"
         ],
-        "orderby": ["orderdate"],
         "overriden": [],
+        "orderby": {
+            "casesubtype": {
+                "mapping_table": "cases.casesubtype",
+                "direction": "ASC"
+            },
+            "orderdate": {
+                "mapping_table": "cases.orderdate",
+                "direction": "ASC"
+            }
+        },
         "casrec": {
             "from_table": "order",
             "overriden": {},
@@ -41,7 +50,7 @@
         "overriden": [
             "address_lines"
         ],
-        "orderby": [],
+        "orderby": {},
         "casrec": {
             "from_table": "pat",
             "overriden": {
@@ -68,7 +77,7 @@
             "caserecnumber"
         ],
         "overriden": [],
-        "orderby": [],
+        "orderby": {},
         "casrec": {
             "from_table": "pat",
             "overriden": {},
@@ -89,7 +98,7 @@
             "person_id"
         ],
         "overriden": [],
-        "orderby": [],
+        "orderby": {},
         "casrec": {
             "from_table": "pat",
             "overriden": {},

--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -1,13 +1,48 @@
 {
+    "bonds": {
+        "exclude": [
+            "order_id"
+        ],
+        "overriden": [],
+        "orderby": {
+            "casesubtype": {
+                "mapping_table": "cases.casesubtype",
+                "direction": "ASC"
+            },
+            "orderdate": {
+                "mapping_table": "cases.orderdate",
+                "direction": "ASC"
+            }
+        },
+        "casrec": {
+            "from_table": "order",
+            "overriden": {},
+            "joins": [
+                "LEFT JOIN casrec_csv.pat ON casrec_csv.pat.\"Case\" = casrec_csv.order.\"Case\""
+            ],
+            "where_clauses": [
+                "casrec_csv.order.\"Bond No.\" != ''"
+            ]
+        },
+        "sirius": {
+            "from_table": "bonds",
+            "overriden": {},
+            "joins": [
+                "LEFT JOIN public.cases ON cases.id = bonds.order_id",
+                "LEFT JOIN public.persons ON persons.id = cases.client_id"
+            ],
+            "where_clauses": []
+        }
+    },
     "cases": {
         "exclude": [
-            "caserecnumber",
-            "person_id",
             "assignee_id",
-            "donor_id",
-            "correspondent_id",
+            "caserecnumber",
             "client_id",
-            "feepayer_id"
+            "correspondent_id",
+            "donor_id",
+            "feepayer_id",
+            "person_id"
         ],
         "overriden": [],
         "orderby": {

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -107,7 +107,7 @@ def drop_exception_tables():
 
 
 def build_exception_table(mapping_name):
-    exclude_cols = validation_dict[mapping_name]['exclude']
+    exclude_cols = validation_dict[mapping_name]['exclude'] + list(validation_dict[mapping_name]['orderby'].keys())
 
     sql_add(f"-- {mapping_name}")
     sql_add(f"CREATE TABLE {get_exception_table(mapping_name)}(")
@@ -115,6 +115,10 @@ def build_exception_table(mapping_name):
 
     # overridden cols (normally run through plsql transform routines)
     for col in validation_dict[mapping_name]['overriden']:
+        sql_add(f"{col} text default NULL,", 1)
+
+    # forced order cols
+    for col in list(validation_dict[mapping_name]['orderby'].keys()):
         sql_add(f"{col} text default NULL,", 1)
 
     # other columns
@@ -153,14 +157,20 @@ def build_lookup_functions():
 
 def get_wrapped_sirius_col(col, mapped_item):
     sql = col
-    if "current_date" == mapping_dict[mapped_item]["transform_casrec"]["calculated"]:
+    col_definition = get_col_definition(mapped_item)
+    if "current_date" == col_definition["transform_casrec"]["calculated"]:
         sql = f"CAST({col} AS DATE)"
     return sql
 
 
 def get_sirius_col_name(mapped_item):
-    col_table = mapping_dict[mapped_item]["sirius_details"]["table_name"]
-    return f"{col_table}.{mapped_item}"
+    col_definition = get_col_definition(mapped_item)
+    col_table = col_definition["sirius_details"]["table_name"]
+    mapped_item_name = mapped_item
+    if isinstance(mapped_item, dict):
+        if mapped_item["mapping_table"]:
+            mapped_item_name = mapped_item["mapping_table"].split('.')[1]
+    return f"{col_table}.{mapped_item_name}"
 
 
 def sirius_wrap(mapped_item):
@@ -170,8 +180,9 @@ def sirius_wrap(mapped_item):
 
 
 def get_wrapped_casrec_col(col, mapped_item):
-    datatype = mapping_dict[mapped_item]["sirius_details"]["data_type"]
-    calculated = mapping_dict[mapped_item]["transform_casrec"]["calculated"]
+    col_definition = get_col_definition(mapped_item)
+    datatype = col_definition["sirius_details"]["data_type"]
+    calculated = col_definition["transform_casrec"]["calculated"]
 
     if datatype not in ["bool", "int"]:
         col = f"NULLIF(TRIM({col}), '')"
@@ -190,9 +201,9 @@ def get_wrapped_casrec_col(col, mapped_item):
 
 
 def get_casrec_column_name(mapped_item):
-    col_definition = mapping_dict[mapped_item]["transform_casrec"]
-    casrec_col_table = col_definition["casrec_table"].lower()
-    casrec_col_name = col_definition["casrec_column_name"]
+    col_definition = get_col_definition(mapped_item)
+    casrec_col_table = col_definition["transform_casrec"]["casrec_table"].lower()
+    casrec_col_name = col_definition["transform_casrec"]["casrec_column_name"]
     return f'{source_schema}.{casrec_col_table}."{casrec_col_name}"'
 
 
@@ -217,9 +228,23 @@ def get_casrec_calculated_value(mapped_item):
     return callables.get(mapping_dict[mapped_item]["transform_casrec"]["calculated"])
 
 
+def get_col_definition(mapped_item):
+    if isinstance(mapped_item, dict) and "mapping_table" in mapped_item:
+        pieces = mapped_item["mapping_table"].split('.')
+        col_mapping = helpers.get_mapping_dict(
+            file_name=pieces[0] + "_mapping", only_complete_fields=True, include_pk=False
+        )
+        col_definition = col_mapping[pieces[1]]
+    else:
+        col_definition = mapping_dict[mapped_item]
+
+    return col_definition
+
+
 def get_casrec_col_source(mapped_item):
     col = ''
-    col_definition = mapping_dict[mapped_item]["transform_casrec"]
+    col_definition = get_col_definition(mapped_item)
+    col_definition = col_definition["transform_casrec"]
     if col_definition["casrec_table"]:
         col = get_casrec_column_name(mapped_item)
         if "" != col_definition["lookup_table"]:
@@ -244,10 +269,10 @@ def casrec_wrap(mapped_item):
 
 
 def build_validation_statements(mapping_name):
-    exclude_cols = validation_dict[mapping_name]['exclude'] + validation_dict[mapping_name]['orderby']
     casrec_overridden_cols = validation_dict[mapping_name]['casrec']['overriden']
     sirius_overridden_cols = validation_dict[mapping_name]['sirius']['overriden']
-    order_by = ",\n        ".join(['caserecnumber ASC'] + validation_dict[mapping_name]['orderby'])
+    exclude_cols = validation_dict[mapping_name]['exclude'] + list(validation_dict[mapping_name]['orderby'].keys())
+    order_by = ",\n        ".join(['caserecnumber ASC'] + list(validation_dict[mapping_name]['orderby'].keys()))
     col_separator = ",\n"
 
     sql_add(f"INSERT INTO {get_exception_table(mapping_name)}(")
@@ -262,12 +287,8 @@ def build_validation_statements(mapping_name):
         sql_add(f"{col} AS {colname},", 3)
 
     # forced order cols
-    sql_add(col_separator.join(
-        [
-            f"            {casrec_wrap(order_col)} AS {order_col},"
-            for order_col in validation_dict[mapping_name]['orderby']
-        ]
-    ))
+    for order_mapped_item_name, order_mapped_item in validation_dict[mapping_name]['orderby'].items():
+        sql_add(f"{casrec_wrap(order_mapped_item)} AS {order_mapped_item_name},", 3)
 
     # standard cols
     sql_add(col_separator.join(
@@ -304,12 +325,8 @@ def build_validation_statements(mapping_name):
         sql_add(f"{col} AS {colname},", 3)
 
     # forced order cols
-    sql_add(col_separator.join(
-        [
-            f"            {sirius_wrap(order_col)} AS {order_col},"
-            for order_col in validation_dict[mapping_name]['orderby']
-        ]
-    ))
+    for order_mapped_item_name, order_mapped_item in validation_dict[mapping_name]['orderby'].items():
+        sql_add(f"{sirius_wrap(order_mapped_item)} AS {order_mapped_item_name},", 3)
 
     # standard cols
     sql_add(col_separator.join(
@@ -343,8 +360,7 @@ def sql_add(sql, indent_level=0, line_breaks=1):
 
 
 def write_column_validation_sql(mapping_name, mapped_item, col_source_casrec, col_source_sirius):
-    order_by = ",\n        ".join(['caserecnumber ASC'] + validation_dict[mapping_name]['orderby'])
-    col_separator = ",\n"
+    order_by = ",\n        ".join(['caserecnumber ASC'] + list(validation_dict[mapping_name]['orderby'].keys()))
 
     sql_add(f"-- {mapping_name} / {mapped_item}")
     sql_add(f"UPDATE {get_exception_table(mapping_name)}")
@@ -357,13 +373,10 @@ def write_column_validation_sql(mapping_name, mapped_item, col_source_casrec, co
     sql_add("SELECT", 3)
     sql_add("exc_table.caserecnumber,", 4) # caserecnumber
     # forced order cols
-    sql_add(col_separator.join(
-        [
-            f"                {casrec_wrap(order_col)} AS {order_col},"
-            for order_col in validation_dict[mapping_name]['orderby']
-        ]
-    ))
-    sql_add(f"{col_source_casrec} AS {mapped_item}", 4) # tested column
+    for order_mapped_item_name, order_mapped_item in validation_dict[mapping_name]['orderby'].items():
+        sql_add(f"{casrec_wrap(order_mapped_item)} AS {order_mapped_item_name},", 4)
+    # tested column
+    sql_add(f"{col_source_casrec} AS {mapped_item}", 4)
     sql_add(f"FROM {source_schema}.{validation_dict[mapping_name]['casrec']['from_table']}", 3)
     for join in validation_dict[mapping_name]['casrec']['joins']:
         sql_add(f"{join}", 3)
@@ -380,13 +393,10 @@ def write_column_validation_sql(mapping_name, mapped_item, col_source_casrec, co
     sql_add("SELECT", 3)
     sql_add("exc_table.caserecnumber,", 4) # caserecnumber
     # forced order cols
-    sql_add(col_separator.join(
-        [
-            f"                {sirius_wrap(order_col)} AS {order_col},"
-            for order_col in validation_dict[mapping_name]['orderby']
-        ]
-    ))
-    sql_add(f"{col_source_sirius} AS {mapped_item}", 4) # tested column
+    for order_mapped_item_name, order_mapped_item in validation_dict[mapping_name]['orderby'].items():
+        sql_add(f"{sirius_wrap(order_mapped_item)} AS {order_mapped_item_name},", 4)
+    # tested column
+    sql_add(f"{col_source_sirius} AS {mapped_item}", 4)
     sql_add(f"FROM {target_schema}.{validation_dict[mapping_name]['sirius']['from_table']}", 3)
     for join in validation_dict[mapping_name]['sirius']['joins']:
         sql_add(f"{join}", 3)

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -47,6 +47,7 @@ source_schema = config.schemas["pre_transform"]
 mapping_dict = None
 
 mappings_to_run = [
+    "bonds",
     "cases",
     "client_addresses",
     "client_persons",
@@ -382,7 +383,10 @@ def write_column_validation_sql(mapping_name, mapped_item, col_source_casrec, co
         sql_add(f"{join}", 3)
     sql_add(f"LEFT JOIN {get_exception_table(mapping_name)} exc_table", 3)
     sql_add('ON exc_table.caserecnumber = pat."Case"', 4)
+    # WHERE
     sql_add("WHERE exc_table.caserecnumber IS NOT NULL", 3)
+    for where_clause in validation_dict[mapping_name]['casrec']['where_clauses']:
+        sql_add(f"AND {where_clause}", 2)
     sql_add(f"ORDER BY {order_by}", 2)
     sql_add(") as csv_data", 2)
 
@@ -402,7 +406,10 @@ def write_column_validation_sql(mapping_name, mapped_item, col_source_casrec, co
         sql_add(f"{join}", 3)
     sql_add(f"LEFT JOIN {get_exception_table(mapping_name)} exc_table", 3)
     sql_add("ON exc_table.caserecnumber = persons.caserecnumber", 4)
+    # WHERE
     sql_add("WHERE exc_table.caserecnumber IS NOT NULL", 3)
+    for where_clause in validation_dict[mapping_name]['sirius']['where_clauses']:
+        sql_add(f"AND {where_clause}", 2)
     sql_add(f"ORDER BY {order_by}", 2)
     sql_add(") as sirius_data", 2)
 


### PR DESCRIPTION
## Purpose
Some entities need to be sorted using columns belonging to other mapping files

If you're sorting DISTINCT by a column, you need to display that column in the SELECT

If you're including the column, you need to format it correctly, inc. passing it through all lookup functions/data converstion etc - which means we actually need to import the full column mapping from another file

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
