### PR TITLE
IN-657 pull case data from preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,35 +15,35 @@ workflows:
       - manage_workflow:
           name: manage workflow
           filters: {branches:{ignore:[master]}}
-      - reset_sirius:
-          name: reset the sirius fixtures development
-          requires: [manage workflow]
-          tf_workspace: development
-          filters: {branches:{ignore:[master]}}
+#      - reset_sirius:
+#          name: reset the sirius fixtures development
+#          requires: [manage workflow]
+#          tf_workspace: development
+#          filters: {branches:{ignore:[master]}}
       - build:
           name: build and unit tests
           requires: [manage workflow]
           filters: {branches:{ignore:[master]}}
-      - infrastructure:
-          name: plan infra development
-          requires: [build and unit tests]
-          tf_workspace: development
-          tf_command: plan
-          filters: {branches:{ignore:[master]}}
-      - infrastructure:
-          name: build infra development
-          requires: [plan infra development]
-          tf_workspace: development
-          tf_command: apply
-          filters: {branches:{ignore:[master]}}
-      - run_step_function:
-          name: run the step function development
-          requires: [build infra development, reset the sirius fixtures development]
-          filters: {branches:{ignore:[master]}}
-      - cleanup:
-          name: destroy branch environment
-          requires: [run the step function development]
-          filters: {branches:{ignore:[master]}}
+#      - infrastructure:
+#          name: plan infra development
+#          requires: [build and unit tests]
+#          tf_workspace: development
+#          tf_command: plan
+#          filters: {branches:{ignore:[master]}}
+#      - infrastructure:
+#          name: build infra development
+#          requires: [plan infra development]
+#          tf_workspace: development
+#          tf_command: apply
+#          filters: {branches:{ignore:[master]}}
+#      - run_step_function:
+#          name: run the step function development
+#          requires: [build infra development, reset the sirius fixtures development]
+#          filters: {branches:{ignore:[master]}}
+#      - cleanup:
+#          name: destroy branch environment
+#          requires: [run the step function development]
+#          filters: {branches:{ignore:[master]}}
 
   master:
     when: << pipeline.parameters.run_master >>
@@ -406,14 +406,14 @@ jobs:
       - run:
           name: Build images
           command: docker-compose -f docker-compose.ci.yml build --parallel
-      - run:
-          name: Full local run through
-          command: |
-            echo "Switching override so we do not use volume mounts"
-            rm docker-compose.override.yml
-            mv docker-compose.override.ci.yml docker-compose.override.yml
-            echo "Running migrate.sh"
-            ./migrate.sh
+#      - run:
+#          name: Full local run through
+#          command: |
+#            echo "Switching override so we do not use volume mounts"
+#            rm docker-compose.override.yml
+#            mv docker-compose.override.ci.yml docker-compose.override.yml
+#            echo "Running migrate.sh"
+#            ./migrate.sh
       - run:
           name: Push images
           command: docker-compose -f docker-compose.ci.yml push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,35 +15,35 @@ workflows:
       - manage_workflow:
           name: manage workflow
           filters: {branches:{ignore:[master]}}
-#      - reset_sirius:
-#          name: reset the sirius fixtures development
-#          requires: [manage workflow]
-#          tf_workspace: development
-#          filters: {branches:{ignore:[master]}}
+      - reset_sirius:
+          name: reset the sirius fixtures development
+          requires: [manage workflow]
+          tf_workspace: development
+          filters: {branches:{ignore:[master]}}
       - build:
           name: build and unit tests
           requires: [manage workflow]
           filters: {branches:{ignore:[master]}}
-#      - infrastructure:
-#          name: plan infra development
-#          requires: [build and unit tests]
-#          tf_workspace: development
-#          tf_command: plan
-#          filters: {branches:{ignore:[master]}}
-#      - infrastructure:
-#          name: build infra development
-#          requires: [plan infra development]
-#          tf_workspace: development
-#          tf_command: apply
-#          filters: {branches:{ignore:[master]}}
-#      - run_step_function:
-#          name: run the step function development
-#          requires: [build infra development, reset the sirius fixtures development]
-#          filters: {branches:{ignore:[master]}}
-#      - cleanup:
-#          name: destroy branch environment
-#          requires: [run the step function development]
-#          filters: {branches:{ignore:[master]}}
+      - infrastructure:
+          name: plan infra development
+          requires: [build and unit tests]
+          tf_workspace: development
+          tf_command: plan
+          filters: {branches:{ignore:[master]}}
+      - infrastructure:
+          name: build infra development
+          requires: [plan infra development]
+          tf_workspace: development
+          tf_command: apply
+          filters: {branches:{ignore:[master]}}
+      - run_step_function:
+          name: run the step function development
+          requires: [build infra development, reset the sirius fixtures development]
+          filters: {branches:{ignore:[master]}}
+      - cleanup:
+          name: destroy branch environment
+          requires: [run the step function development]
+          filters: {branches:{ignore:[master]}}
 
   master:
     when: << pipeline.parameters.run_master >>
@@ -406,14 +406,14 @@ jobs:
       - run:
           name: Build images
           command: docker-compose -f docker-compose.ci.yml build --parallel
-#      - run:
-#          name: Full local run through
-#          command: |
-#            echo "Switching override so we do not use volume mounts"
-#            rm docker-compose.override.yml
-#            mv docker-compose.override.ci.yml docker-compose.override.yml
-#            echo "Running migrate.sh"
-#            ./migrate.sh
+      - run:
+          name: Full local run through
+          command: |
+            echo "Switching override so we do not use volume mounts"
+            rm docker-compose.override.yml
+            mv docker-compose.override.ci.yml docker-compose.override.yml
+            echo "Running migrate.sh"
+            ./migrate.sh
       - run:
           name: Push images
           command: docker-compose -f docker-compose.ci.yml push

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,9 @@ casrec_data/do_anonymising/change_log.txt
 *PLAY*
 .pg_restore.api.log
 sirius-snapshot
-data/anon_data/
+data/
 *terraform.output.json
+*terraform.output_casrec.json
 *etl*.sql
 *integration*.sql
 migration_steps/shared/sql/temp/*.sql

--- a/casrec_data/run_ecs_task/Dockerfile
+++ b/casrec_data/run_ecs_task/Dockerfile
@@ -1,0 +1,4 @@
+FROM opg_casrec_migration_base_image:latest
+RUN apt-get install -y postgresql-client
+COPY run_ecs_task.py /run_ecs_task.py
+CMD ["echo", "NO_OP"]

--- a/casrec_data/run_ecs_task/run_ecs_task.py
+++ b/casrec_data/run_ecs_task/run_ecs_task.py
@@ -1,0 +1,108 @@
+import boto3
+import json
+import os
+import click
+
+
+def operator_session(environment):
+
+    account = {"development": "288342028542", "preproduction": "492687888235"}
+    client = boto3.client("sts")
+
+    role_to_assume = f"arn:aws:iam::{account[environment]}:role/breakglass"
+    response = client.assume_role(
+        RoleArn=role_to_assume, RoleSessionName="assumed_role"
+    )
+
+    session = boto3.Session(
+        aws_access_key_id=response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+        aws_session_token=response["Credentials"]["SessionToken"],
+    )
+
+    return session
+
+
+def run_ecs_task(client, caserecnumber):
+    with open("/terraform/terraform.output_casrec.json") as json_file:
+        data = json.load(json_file)
+
+    response = client.run_task(
+        cluster=data["Tasks"]["value"]["pull-case"]["Cluster"],
+        launchType="FARGATE",
+        taskDefinition=data["Tasks"]["value"]["pull-case"]["TaskDefinition"],
+        count=1,
+        platformVersion="LATEST",
+        networkConfiguration={
+            "awsvpcConfiguration": {
+                "subnets": data["Tasks"]["value"]["pull-case"]["NetworkConfiguration"][
+                    "AwsvpcConfiguration"
+                ]["Subnets"],
+                "securityGroups": data["Tasks"]["value"]["pull-case"][
+                    "NetworkConfiguration"
+                ]["AwsvpcConfiguration"]["SecurityGroups"],
+            }
+        },
+        overrides={
+            "containerOverrides": [
+                {
+                    "name": "etl0",
+                    "command": [
+                        "python3",
+                        "prepare/case_details_to_s3/app/app.py",
+                        "-c",
+                        caserecnumber,
+                    ],
+                },
+            ],
+        },
+    )
+    return response
+
+
+def wait_for_task_to_stop(client, cluster_arn, task_arn):
+    waiter = client.get_waiter("tasks_stopped")
+    response = waiter.wait(
+        cluster=cluster_arn,
+        tasks=[task_arn,],
+        include=["TAGS",],
+        WaiterConfig={"Delay": 6, "MaxAttempts": 100},
+    )
+
+    return response
+
+
+def get_stop_exit_code(client, cluster_arn, task_arn):
+    response = client.describe_tasks(
+        cluster=cluster_arn, tasks=[task_arn,], include=["TAGS",]
+    )
+    exit_code = response["tasks"][0]["stopCode"]
+    stop_reason = response["tasks"][0]["stoppedReason"]
+
+    return exit_code, stop_reason
+
+
+@click.command()
+@click.option("-c", "--caserecnumber", default="10000037")
+def main(caserecnumber):
+    environment = os.getenv("ENVIRONMENT")
+    op_session = operator_session(environment)
+    client = op_session.client("ecs", region_name="eu-west-1")
+    response = run_ecs_task(client, caserecnumber)
+    task_arn = response["tasks"][0]["containers"][0]["taskArn"]
+    cluster_arn = response["tasks"][0]["clusterArn"]
+    print(f"Running against task: {task_arn}")
+    print(f"Running against cluster: {cluster_arn}")
+    wait_for_task_to_stop(client, cluster_arn, task_arn)
+    code, reason = get_stop_exit_code(client, cluster_arn, task_arn)
+
+    if code == "EssentialContainerExited":
+        print("Container ran correctly - checking logs...")
+        # Add logging here...
+    else:
+        print(f"{code} - {reason}")
+        print("There was a problem with your run. Check ECS")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.commands.yml
+++ b/docker-compose.commands.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+services:
+  case_to_s3:
+    build:
+      context: ./casrec_data/run_ecs_task
+      dockerfile: Dockerfile
+    environment:
+      AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
+      AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+      AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN
+      ENVIRONMENT: preproduction
+    volumes:
+      - ./casrec_data/run_ecs_task/run_ecs_task.py:/run_ecs_task.py
+      - ./terraform:/terraform

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,6 +19,7 @@ services:
       - ./migration_steps/prepare/prepare.sh:/prepare/prepare.sh
       - ./migration_steps/prepare/prepare_target:/prepare/prepare_target
       - ./migration_steps/prepare/create_stage_schema:/prepare/create_stage_schema
+      - ./migration_steps/prepare/case_details_to_s3:/prepare/case_details_to_s3
       - ./migration_steps/shared:/shared
 
   load_casrec:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,13 @@ services:
         - DEFAULT_REGION=eu-west-1
   load_s3:
     build:
-      context: ./migration_steps/load_s3
-      dockerfile: Dockerfile
+      context: ./migration_steps
+      dockerfile: load_s3-dockerfile
     environment:
       CSV_DIR_SUFFIX: ./data/anon_data
       LOCALSTACK_URL: localstack
     volumes:
-      - ./data/anon_data:/data/anon_data
+      - ./data:/data
   prepare:
     build:
       context: ./migration_steps

--- a/migration_steps/load_s3-dockerfile
+++ b/migration_steps/load_s3-dockerfile
@@ -1,0 +1,6 @@
+FROM opg_casrec_migration_base_image:latest
+COPY /requirements.txt /requirements.txt
+RUN pip3 install -r requirements.txt
+COPY load_s3/load_s3_local.py /load_s3_local.py
+COPY load_s3/synchronise_s3.py /synchronise_s3.py
+CMD ["echo", "NO_OP"]

--- a/migration_steps/load_s3/Dockerfile
+++ b/migration_steps/load_s3/Dockerfile
@@ -1,5 +1,0 @@
-FROM opg_casrec_migration_base_image:latest
-COPY ./load_s3_local.py /load_s3_local.py
-COPY ./synchronise_s3.py /synchronise_s3.py
-COPY ./local_s3.sh /local_s3.sh
-CMD ["echo", "NO_OP"]

--- a/migration_steps/load_s3/synchronise_s3.py
+++ b/migration_steps/load_s3/synchronise_s3.py
@@ -2,16 +2,19 @@ import time
 import boto3
 import os
 import shutil
+import click
+import pandas as pd
 from pathlib import Path
 
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
 
 
-def operator_session():
+def operator_session(environment):
 
+    account = {"development": "288342028542", "preproduction": "492687888235"}
     client = boto3.client("sts")
 
-    role_to_assume = f"arn:aws:iam::288342028542:role/operator"
+    role_to_assume = f"arn:aws:iam::{account[environment]}:role/operator"
     response = client.assume_role(
         RoleArn=role_to_assume, RoleSessionName="assumed_role"
     )
@@ -25,7 +28,8 @@ def operator_session():
     return session
 
 
-def get_list_of_files(bucket_name, s3, local_data_path):
+def download_list_of_files(bucket_name, s3, local_data_path, s3_folder):
+    print("Starting download of files")
     resp = s3.list_objects_v2(Bucket=bucket_name)
     files_in_bucket = []
 
@@ -34,13 +38,12 @@ def get_list_of_files(bucket_name, s3, local_data_path):
         folder = file_and_folder.split("/")[0]
         file = file_and_folder.split("/")[1]
         dl_file_location = str(local_data_path) + "/" + file
-        if folder == "anon" and file.endswith(".csv"):
+        if folder == s3_folder and file.endswith(".csv"):
             s3.download_file(bucket_name, file_and_folder, dl_file_location)
             print(file_and_folder)
             files_in_bucket.append(file_and_folder)
 
     print(f"Total files returned: {len(files_in_bucket)}")
-    return files_in_bucket
 
 
 def clear_folder(folder):
@@ -53,17 +56,54 @@ def clear_folder(folder):
                 shutil.rmtree(file_path)
         except Exception as e:
             print("Failed to delete %s. Reason: %s" % (file_path, e))
+    print("Cleared folder")
 
 
-def main():
+def merge_edge_cases_locally(edge_data_path, local_data_path):
+    for filename in os.listdir(edge_data_path):
+        edge_data = pd.read_csv(edge_data_path / filename)
+        original_csv = local_data_path / filename.replace("_anon", "")
+        max_id = pd.read_csv(original_csv)["rct"].max()
+
+        edge_data[edge_data.columns[0]] += max_id + 1
+        edge_data.insert(1, "rct", edge_data[edge_data.columns[0]], True)
+        if filename == "pat_anon.csv":
+            edge_data.insert(2, "by", "MIG", True)
+        print(f"Adding data to {original_csv}")
+        add_new_lines(original_csv)
+        edge_data.to_csv(original_csv, mode="a", header=False, index=False)
+
+
+def add_new_lines(csv_path):
+    with open(csv_path, "r") as f:
+        f.seek(0, 2)
+        f.seek(f.tell() - 2, 0)
+        elems = f.read()
+        for elem in elems:
+            last_elem = elem
+        if last_elem != "\n":
+            with open(csv_path, "a") as f2:
+                f2.write("\n")
+
+
+@click.command()
+@click.option("-e", "--environment", default="development")
+def main(environment):
     csv_dir_suffix = os.getenv("CSV_DIR_SUFFIX")
-    bucket = "casrec-migration-development"
-    s3_session = operator_session()
+    bucket = f"casrec-migration-{environment}"
+    s3_session = operator_session(environment)
     s3 = s3_session.client("s3")
     local_data_path = current_path / csv_dir_suffix
-    clear_folder(local_data_path)
 
-    get_list_of_files(bucket, s3, local_data_path)
+    if environment == "development":
+        clear_folder(local_data_path)
+        download_list_of_files(bucket, s3, local_data_path, "anon")
+        print("Finished syncing data from dev environment")
+    elif environment == "preproduction":
+        edge_data_path = local_data_path / "../edge_cases_csvs"
+        download_list_of_files(bucket, s3, edge_data_path, "edge_cases_csvs")
+        merge_edge_cases_locally(edge_data_path, local_data_path)
+        print("Finished adding edge cases to your data set")
 
 
 if __name__ == "__main__":

--- a/migration_steps/prepare-dockerfile
+++ b/migration_steps/prepare-dockerfile
@@ -3,7 +3,9 @@ RUN apt-get install -y postgresql-client
 COPY /requirements.txt /requirements.txt
 RUN pip3 install -r requirements.txt
 COPY prepare/prepare.sh /prepare/prepare.sh
+COPY prepare/test_echo.sh /prepare/test_echo.sh
 COPY prepare/prepare_target /prepare/prepare_target
 COPY prepare/create_stage_schema /prepare/create_stage_schema
+COPY prepare/pull_case_from_pre /prepare/pull_case_from_pre
 COPY shared /shared
 CMD ["echo", "NO_OP"]

--- a/migration_steps/prepare-dockerfile
+++ b/migration_steps/prepare-dockerfile
@@ -6,6 +6,6 @@ COPY prepare/prepare.sh /prepare/prepare.sh
 COPY prepare/test_echo.sh /prepare/test_echo.sh
 COPY prepare/prepare_target /prepare/prepare_target
 COPY prepare/create_stage_schema /prepare/create_stage_schema
-COPY prepare/pull_case_from_pre /prepare/pull_case_from_pre
+COPY prepare/case_details_to_s3 /prepare/case_details_to_s3
 COPY shared /shared
 CMD ["echo", "NO_OP"]

--- a/migration_steps/prepare/case_details_to_s3/app/app.py
+++ b/migration_steps/prepare/case_details_to_s3/app/app.py
@@ -1,0 +1,348 @@
+import sys
+import os
+import random
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import time
+from helpers import get_config
+from dotenv import load_dotenv
+import helpers
+from db_helpers import *
+from helpers import *
+import logging
+import custom_logger
+import click
+from sqlalchemy import create_engine
+import pandas as pd
+import pprint
+import boto3
+from faker import Faker
+
+pp = pprint.PrettyPrinter(indent=4)
+
+env_path = current_path / "../../../../.env"
+shared_path = current_path / "../../../shared"
+temp_csv_path = shared_path / "temp/csvs"
+load_dotenv(dotenv_path=env_path)
+
+environment = os.environ.get("ENVIRONMENT")
+config = get_config(environment)
+
+# logging
+log = logging.getLogger("root")
+log.addHandler(custom_logger.MyHandler())
+config.custom_log_level()
+verbosity_levels = config.verbosity_levels
+
+engine = None
+target_schema = None
+source_schema = config.schemas["pre_transform"]
+mapping_dict = None
+
+host = os.environ.get("DB_HOST")
+ci = os.getenv("CI")
+bucket_name = f"casrec-migration-{environment.lower()}"
+account = os.environ["SIRIUS_ACCOUNT"]
+session = boto3.session.Session()
+
+
+def get_anon_id():
+    return {
+        "first_name": {"include": ["forename", "firstname", "aka"], "exclude": [],},
+        "surname": {"include": ["surname", "lastname", "last_name"], "exclude": [],},
+        "full_name": {"include": ["name"], "exclude": [],},
+        "title": {"include": ["title"], "exclude": [],},
+        "initial": {"include": ["init"], "exclude": ["Rev_Init"],},
+        "dob": {"include": ["dob"], "exclude": [],},
+        "birth_year": {"include": ["birth_yr"], "exclude": [],},
+        "email": {"include": ["email"], "exclude": ["by_Email"],},
+        "phone": {
+            "include": ["phone", "mobile", "tele"],
+            "exclude": ["Papers_to_Phone", "Papers to Phone", "Assrc_Tele_Comp"],
+        },
+        "address": {"include": ["adrs"], "exclude": [],},
+        "postcode": {"include": ["postcode"], "exclude": [],},
+        "free_text": {
+            "include": ["comment", "note", "remarks", "sup_desc", "sup desc"],
+            "exclude": [],
+        },
+        "documents": {"include": ["docid"], "exclude": [],},
+        "payslip": {"include": ["payslip"], "exclude": []},
+        "solicitor_name": {
+            "include": ["sender_co", "sender co", "pathfinder", "pathfinder"],
+            "exclude": [],
+        },
+    }
+
+
+def get_cols(data_name, columns, exact_match=False):
+
+    include_cols = get_anon_id()[data_name]["include"]
+    exclude_cols = get_anon_id()[data_name]["exclude"]
+
+    if exact_match:
+        matching_columns = [x for x in columns if x.lower() in include_cols]
+        cols_to_change = [x for x in matching_columns if x not in exclude_cols]
+    else:
+        matching_columns = [
+            x for x in columns if any(i in x.lower() for i in include_cols)
+        ]
+        cols_to_change = [x for x in matching_columns if x not in exclude_cols]
+
+    return cols_to_change
+
+
+def anonymise_data(data):
+    fake = Faker("en-GB")
+    file_start = time.time()
+    columns_changed = []
+
+    df = data
+
+    # Names
+    titles = get_cols("title", df.columns)
+    first_names = get_cols("first_name", df.columns)
+    initials = get_cols("initial", df.columns)
+    surnames = get_cols("surname", df.columns)
+    full_names = get_cols("full_name", df.columns, exact_match=True)
+
+    # dob
+    dobs = get_cols("dob", df.columns)
+    birth_years = get_cols("birth_year", df.columns)
+
+    # email
+    emails = get_cols("email", df.columns)
+
+    # phone
+    phones = get_cols("phone", df.columns)
+
+    # address
+    addresses = get_cols("address", df.columns)
+    postcodes = get_cols("postcode", df.columns)
+
+    # free text
+    free_text_fields = get_cols("free_text", df.columns)
+
+    # documents
+    documents = get_cols("documents", df.columns)
+
+    # payslip
+    payslips = get_cols("payslip", df.columns)
+
+    # solicitor
+    solicitor_names = get_cols("solicitor_name", df.columns)
+
+    for index in df.index:
+
+        replacements = [
+            {"col_list": titles, "fake_data": fake.prefix_nonbinary(),},
+            {"col_list": first_names, "fake_data": fake.first_name_nonbinary(),},
+            {"col_list": surnames, "fake_data": fake.last_name_nonbinary(),},
+            {"col_list": full_names, "fake_data": fake.name(),},
+            {"col_list": dobs, "fake_data": fake.date(pattern="%Y-%m-%d %H:%M:%S"),},
+            {"col_list": emails, "fake_data": fake.email(),},
+            {"col_list": phones, "fake_data": fake.phone_number(),},
+            {"col_list": postcodes, "fake_data": fake.postcode(),},
+            {"col_list": free_text_fields, "fake_data": fake.catch_phrase(),},
+            {
+                "col_list": solicitor_names,
+                "fake_data": f"{fake.company()} {fake.company_suffix()}",
+            },
+            {"col_list": payslips, "fake_data": random.randint(100000, 1000000),},
+        ]
+
+        # simple replacements
+        for r in replacements:
+            if len(r["col_list"]) > 0:
+                for i, col in enumerate(r["col_list"], start=1):
+                    df.loc[index, col] = r["fake_data"]
+
+                if r["col_list"] not in columns_changed:
+                    columns_changed.append(r["col_list"])
+
+        # complicated replacements
+        if len(addresses) > 0:
+            fake_address = fake.address()
+            if len(addresses) > 1:
+                for i, line in enumerate(addresses, start=0):
+                    try:
+                        df.loc[index, line] = fake_address.split("\n")[i]
+                    except Exception:
+                        df.loc[index, line] = ""
+
+                if addresses not in columns_changed:
+                    columns_changed.append(addresses)
+            else:
+                df.loc[index, addresses] = fake_address
+                if addresses not in columns_changed:
+                    columns_changed.append(addresses)
+
+        # replacements that rely on other column data
+        if len(initials) > 0 and len(first_names) > 0:
+            df.loc[index, initials] = df.loc[index, first_names][0][0]
+            if initials not in columns_changed:
+                columns_changed.append(initials)
+
+        if len(birth_years) > 0 and len(dobs) > 0:
+            df.loc[index, birth_years] = df.loc[index, dobs][0][:4]
+            if birth_years not in columns_changed:
+                columns_changed.append(birth_years)
+
+        if len(documents) > 0:
+            try:
+                rec_date = [
+                    x for x in df.columns if x.lower() in ["date_rcvd", "date rcvd"]
+                ]
+                df.loc[index, documents] = (
+                    f"{random.randint(100000, 1000000)}  "
+                    f"{df.loc[index, rec_date][0]} "
+                    f"{df.loc[index, 'Case']} "
+                    f"{df.loc[index, surnames][0]}"
+                )
+            except Exception:
+                df.loc[index, documents] = fake.catch_phrase()
+            if documents not in columns_changed:
+                columns_changed.append(documents)
+
+    column_list = [", ".join(x) for x in columns_changed]
+    log.info(f"Columns anonymised: {', '.join(column_list)}")
+
+    log.info(
+        f"===== Finished anonymising {len(df)} rows in"
+        f" {round(time.time() - file_start, 2)} secs "
+        f"===== \n\n"
+    )
+
+    return df
+
+
+def set_logging_level(verbose):
+    try:
+        log.setLevel(verbosity_levels[verbose])
+    except KeyError:
+        log.setLevel("INFO")
+        log.info(f"{verbose} is not a valid verbosity level")
+
+
+def get_primary_keys(case_ref):
+    sql = f"""
+    SELECT DISTINCT
+    p."Case" as case,
+    o."Order No" as order_no,
+    d."Deputy No" as deputy_no,
+    ds."Dep Addr No" as dep_addr_no
+    FROM casrec_csv.pat as p
+    LEFT JOIN casrec_csv.order as o ON p."Case" = o."Case"
+    LEFT JOIN casrec_csv.deputyship  as ds ON o."Order No" = ds."Order No"
+    LEFT JOIN casrec_csv.deputy as d ON ds."Deputy No" = d."Deputy No"
+    LEFT JOIN casrec_csv.account as a ON a."Case" = p."Case"
+    LEFT JOIN casrec_csv.deputy_address as da ON da."Dep Addr No" = ds."Dep Addr No"
+    WHERE p."Case" = '{case_ref}'
+    """
+
+    results = pd.read_sql_query(sql, engine)
+
+    return results
+
+
+def lower_snake(string):
+    formatted_string = string.lower().replace(" ", "_")
+    return formatted_string
+
+
+def get_list_of_tables(pks, tables):
+    list_of_tables = []
+    log.info("in here...")
+    log.info(pks)
+    for table_pair in tables:
+        log.info(table_pair)
+        column_fmt = lower_snake(table_pair["pk"])
+        log.info(pks[column_fmt])
+        pks_fmt = "', '".join(
+            list(
+                set(
+                    pks[column_fmt]
+                    .dropna()
+                    .astype(int, errors="ignore")
+                    .astype(str)
+                    .tolist()
+                )
+            )
+        )
+        sql = f"""
+        SELECT *
+        FROM casrec_csv.{table_pair['table']}
+        WHERE "{table_pair['pk']}" in ('{pks_fmt}')
+        """
+        log.info(sql)
+        results = pd.read_sql_query(sql, engine)
+        results.drop(
+            columns=["casrec_row_id", "csv_record"], inplace=True, errors="ignore"
+        )
+
+        result_pair = {"table_name": table_pair["table"], "table_results": results}
+
+        list_of_tables.append(result_pair)
+
+    return list_of_tables
+
+
+def set_connection_target():
+    global engine
+    db_config = "migration"
+    db_conn_string = config.get_db_connection_string(db_config)
+    engine = create_engine(db_conn_string)
+
+
+def updload_csvs_to_s3():
+    s3 = get_s3_session(session, environment, host)
+    if ci != "true":
+        for file in os.listdir(temp_csv_path):
+            if file.endswith(".csv"):
+                file_path = f"{temp_csv_path}/{file}"
+                s3_file_path = f"edge_cases_csvs/{file}"
+                upload_file(bucket_name, file_path, s3, log, s3_file_path)
+
+
+@click.command()
+@click.option("-v", "--verbose", count=True)
+@click.option("-c", "--caserecnumber", default="10000037")
+def main(verbose, caserecnumber):
+    set_logging_level(verbose)
+    log.info(helpers.log_title(message="Extract and Anonymise Case"))
+
+    set_connection_target()
+
+    table_names = [
+        {"table": "pat", "pk": "Case"},
+        {"table": "order", "pk": "Order No"},
+        {"table": "deputyship", "pk": "Order No"},
+        {"table": "deputy", "pk": "Deputy No"},
+        {"table": "deputy_address", "pk": "Dep Addr No"},
+    ]
+    log.info("=== GETTING DATA FOR CSVs (SQL below) ===")
+    tables = get_list_of_tables(get_primary_keys(caserecnumber), table_names)
+
+    log.info("=== ANONYMISING DATA ===")
+    for table in tables:
+        log.info(f"= {table['table_name']} =")
+        table_name = table["table_name"]
+        table["table_results"].to_csv(f"/shared/{table_name}.csv")
+        anon_table = anonymise_data(table["table_results"])
+        anon_table.to_csv(f"{temp_csv_path}/{table_name}_anon.csv")
+    log.info("=== UPLOADING TO S3 ===")
+    updload_csvs_to_s3()
+
+
+if __name__ == "__main__":
+    t = time.process_time()
+
+    log.setLevel(1)
+    log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
+
+    main()
+
+    print(f"Total time: {round(time.process_time() - t, 2)}")

--- a/migration_steps/prepare/prepare_target/app/app.py
+++ b/migration_steps/prepare/prepare_target/app/app.py
@@ -40,7 +40,7 @@ def set_logging_level(verbose):
 
 @click.command()
 @click.option("-v", "--verbose", count=True)
-@click.option("-i", "--ignore_schemas", default="")
+@click.option("-i", "--ignore_schemas", default="reference")
 def main(verbose, ignore_schemas):
     set_logging_level(verbose)
     log.info(log_title(message="Prepare Target"))

--- a/migration_steps/prepare/test_echo.sh
+++ b/migration_steps/prepare/test_echo.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "THIS IS A TEST TO SEE IF WE CAN RUN THIS"

--- a/migration_steps/requirements.txt
+++ b/migration_steps/requirements.txt
@@ -22,3 +22,4 @@ pytest==6.1.2
 pytest_cases==2.7.2
 pytest-cov==2.10.1
 psutil==5.8.0
+faker

--- a/run_ecs_task.sh
+++ b/run_ecs_task.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+cd terraform
+echo "----- INITIALIZING TERRAFORM -----"
+export TF_WORKSPACE=default
+export TF_VAR_default_role=breakglass
+export TF_VAR_management_role=operator
+export TF_VAR_image_tag=fake_tag
+export management_role
+export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true"
+aws-vault exec identity -- terraform init -input=false -upgrade=true -reconfigure
+export TF_WORKSPACE=preproduction
+echo "----- CREATING TEMPLATE FILE TO RUN EXTRACT JOB -----"
+aws-vault exec identity -- terraform apply -input=false -auto-approve -target=local_file.output_casrec
+cd ..
+echo "----- RUNNING ECS TASK TO EXTRACT DATA TO S3 -----"
+aws-vault exec identity -- docker-compose -f docker-compose.commands.yml run --rm case_to_s3 python3 run_ecs_task.py -c 10020349
+echo "----- PULLING ANON S3 DATA FROM PREPROD TO LOCAL -----"
+aws-vault exec identity -- docker-compose run --rm load_s3 python3 synchronise_s3.py -e preproduction
+echo "----- RESULTS MERGED WITH LOCAL DATA -----"

--- a/terraform/casrec_tasks.toml
+++ b/terraform/casrec_tasks.toml
@@ -1,0 +1,27 @@
+{
+  "Role": {
+    "sensitive": false,
+    "type": "string",
+    "value": "arn:aws:iam::${account}:role/sirius-ci"
+  },
+  "Tasks": {
+    "sensitive": false,
+    "value": {
+      "pull-case": {
+        "Cluster": "${cluster}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "SecurityGroups": [
+              "${sec_group}"
+            ],
+            "Subnets": [
+              ${subnets}
+            ]
+          }
+        },
+        "TaskDefinition": "${task-definition}"
+      }
+    }
+  }
+}

--- a/terraform/template.tf
+++ b/terraform/template.tf
@@ -16,3 +16,15 @@ resource "local_file" "output" {
   })
   filename = "${path.module}/terraform.output.json"
 }
+
+resource "local_file" "output_casrec" {
+  content = templatefile("${path.module}/casrec_tasks.toml",
+    {
+      cluster         = aws_ecs_cluster.migration.name,
+      sec_group       = aws_security_group.etl.id,
+      subnets         = local.subnets_string,
+      account         = local.account.account_id
+      task-definition = aws_ecs_task_definition.etl0.arn
+  })
+  filename = "${path.module}/terraform.output_casrec.json"
+}


### PR DESCRIPTION
## Purpose

When we encounter issues in our data we want to be able to recreate them in our dev data so that we can debug locally.
We have an automated system to do this. It is a work in progress as the method to actually achieve
this is surprisingly complicated.

## Approach

- Initialises terraform and runs a job that populates a template. This stops us needing to hard code the subnet values etc.
- Kicks off a container that runs an ECS task. We have added the script to do the anonymising and moving of date to s3
to the etl0 (prepare job) and this gets called with an override.
- ECS task pulls the relevant data, anonymises it, formats it and puts it in a folder in s3 ready for download.
- We then kick off the synchronise script using preproduction as the environment parameter. This downloads the data locally
and merges it with out existing local data.

If you are happy with the data then you can manually add the files to the dev s3 bucket. We may automate this bit but for now I'd rather
we didn't accidentally overwrite the s3 bucket data.

## Further work...

I need to move on from this for now. There is some further work needed that will allow anyone to use it as currently you need breakglass. Also need to add logging to the ECS task. Can expand on the entities. It seems we don't use many tables from casrec currently but we ought to expand this out.

## Learning

NA
## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
