### PR TITLE
In 633

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -30,6 +30,7 @@ services:
     volumes:
       - ./migration_steps/transform_casrec/transform:/transform_casrec/transform
       - ./migration_steps/transform_casrec/additional_data:/transform_casrec/additional_data
+      - ./migration_steps/transform_casrec/filter_data:/transform_casrec/filter_data
       - ./migration_steps/transform_casrec/transform.sh:/transform_casrec/transform.sh
       - ./migration_steps/shared:/shared
 

--- a/migrate.sh
+++ b/migrate.sh
@@ -5,6 +5,7 @@ RELOAD="y"
 RESYNC="y"
 SKIP_LOAD="false"
 PRESERVE_SCHEMAS=""
+LAY_TEAM=""
 GENERATE_DOCS=false
 
 if [ "${CI}" != "true" ]
@@ -22,6 +23,12 @@ then
     PRESERVE_SCHEMAS="casrec_csv"
     SKIP_LOAD="true"
   fi
+  read -p "Migrate specific Lay Team? (1-9) [All]: " LAY_TEAM
+  if [ "${LAY_TEAM}" == "" ]
+  then
+      echo "Migrating ALL Lay teams"
+  else
+      echo "Migrating Lay Team ${LAY_TEAM} only"
   fi
 fi
 
@@ -67,7 +74,7 @@ wait $P1 $P2 $P3 $P4
 cat docker_load.log
 rm docker_load.log
 echo "=== Step 1 - Transform ==="
-docker-compose run --rm transform_casrec transform_casrec/transform.sh --clear=True
+docker-compose run --rm transform_casrec transform_casrec/transform.sh --team="${LAY_TEAM}"
 echo "=== Step 2 - Integrate with Sirius ==="
 docker-compose run --rm integration integration/integration.sh
 echo "=== Step 3 - Validate Staging ==="

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,41 +1,40 @@
 #!/bin/bash
 set -e
 
-NO_RELOAD=false
+RELOAD="y"
+RESYNC="y"
+SKIP_LOAD="false"
+PRESERVE_SCHEMAS=""
 GENERATE_DOCS=false
 
 if [ "${CI}" != "true" ]
 then
-  read -p "Do you want to resync? (y/n) [n]: " RESYNC
-  RESYNC=${RESYNC:-n}
-  echo $RESYNC
-  # Only do this if sure the data in casrec_csv schema is correct)
-  read -p "Do you want to skip reload into localstack? (y/n) [n]: " NO_RELOAD
-  NO_RELOAD=${NO_RELOAD:-n}
-  echo $NO_RELOAD
-  if [ ${NO_RELOAD} == "y" ]
+  # Skip this if sure the data in casrec_csv schema is correct)
+  read -p "Rebuild casrec_csv schema from .csv files? (y/n) [n]: " RELOAD
+  RELOAD=${RELOAD:-n}
+  echo $RELOAD
+  if [ "${RELOAD}" == "y" ]
   then
-    NO_RELOAD="true"
-    echo "IN HERE"
-    echo $NO_RELOAD
+      read -p "Sync local .csv files from S3? (y/n) [n]: " RESYNC
+      RESYNC=${RESYNC:-n}
+      echo $RESYNC
+  else
+    PRESERVE_SCHEMAS="casrec_csv"
+    SKIP_LOAD="true"
+  fi
   fi
 fi
 
 START_TIME=`date +%s`
 
-if [ "${NO_RELOAD}" == "true" ]
-  then
-  echo "=== Setting no reload settings ==="
-  SKIP_SCHEMAS="casrec_csv"
-  SKIP_LOAD="true"
-fi
 # Docker compose file for circle build
 docker build base_image -t opg_casrec_migration_base_image:latest
 docker-compose up --no-deps -d casrec_db localstack postgres-sirius
 docker-compose run --rm wait-for-it -address postgres-sirius:5432 --timeout=30 -debug
 docker-compose run --rm wait-for-it -address casrec_db:5432 --timeout=30 -debug
 docker-compose up --no-deps -d postgres-sirius-restore
-if [ "${NO_RELOAD}" != "true" ]
+
+if [ "${RELOAD}" == "y" ]
 then
   if [ "${CI}" != "true" ]
   then
@@ -51,7 +50,7 @@ then
     docker-compose up --no-deps -d postgres-sirius-restore
   fi
 fi
-docker-compose run --rm prepare prepare/prepare.sh -i "${SKIP_SCHEMAS}"
+docker-compose run --rm prepare prepare/prepare.sh -i "${PRESERVE_SCHEMAS}"
 docker rm casrec_load_1 &>/dev/null || echo "casrec_load_1 does not exist. This is OK"
 docker rm casrec_load_2 &>/dev/null || echo "casrec_load_2 does not exist. This is OK"
 docker rm casrec_load_3 &>/dev/null || echo "casrec_load_3 does not exist. This is OK"

--- a/migration_steps/prepare/prepare.sh
+++ b/migration_steps/prepare/prepare.sh
@@ -4,7 +4,7 @@ while getopts i: option
 do
   case "${option}"
   in
-    i) IGNORE=${OPTARG};;
+    i) SCHEMAS=${OPTARG};;
     *) echo "usage: $0 [-i]" >&2
            exit 1 ;;
   esac
@@ -12,5 +12,5 @@ done
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-python3 "${DIR}/prepare_target/app/app.py" --ignore_schemas="${IGNORE}"
+python3 "${DIR}/prepare_target/app/app.py" --preserve_schemas="${SCHEMAS}"
 python3 "${DIR}/create_stage_schema/app/app.py"

--- a/migration_steps/prepare/prepare_target/app/app.py
+++ b/migration_steps/prepare/prepare_target/app/app.py
@@ -40,15 +40,15 @@ def set_logging_level(verbose):
 
 @click.command()
 @click.option("-v", "--verbose", count=True)
-@click.option("-i", "--ignore_schemas", default="reference")
-def main(verbose, ignore_schemas):
+@click.option("-i", "--preserve_schemas", default="reference")
+def main(verbose, preserve_schemas):
     set_logging_level(verbose)
     log.info(log_title(message="Prepare Target"))
 
     log.info("Perform Sirius DB Housekeeping")
     conn_target = psycopg2.connect(config.get_db_connection_string("target"))
     conn_source = psycopg2.connect(config.get_db_connection_string("migration"))
-    delete_all_schemas(log=log, conn=conn_source, ignore_schemas=ignore_schemas)
+    delete_all_schemas(log=log, conn=conn_source, preserve_schemas=preserve_schemas)
     log.info("Deleted Schemas")
     log.debug(
         "(operations which need to be performed on Sirius DB ahead of the final Casrec Migration)"

--- a/migration_steps/shared/db_helpers.py
+++ b/migration_steps/shared/db_helpers.py
@@ -12,14 +12,14 @@ from psycopg2.extensions import register_adapter, AsIs
 psycopg2.extensions.register_adapter(np.int64, psycopg2._psycopg.AsIs)
 
 
-def delete_all_schemas(log, conn, ignore_schemas):
+def delete_all_schemas(log, conn, preserve_schemas):
     cursor = conn.cursor()
-    if ignore_schemas != "":
-        ignore_list = ignore_schemas.split(",")
-        ignore_schemas = "'" + "', '".join(ignore_list) + "', "
-        for ignore_schema in ignore_list:
-            log.info(f"Checking schema: {ignore_schema}")
-            if ignore_schema == "casrec_csv":
+    if preserve_schemas != "":
+        schemas_list = preserve_schemas.split(",")
+        preserve_schemas = "'" + "', '".join(schemas_list) + "', "
+        for preserve_schema in schemas_list:
+            log.info(f"Checking schema: {preserve_schema}")
+            if preserve_schema == "casrec_csv":
                 drop_statement = """
                     DROP TABLE IF EXISTS "casrec_csv"."migration_progress";
                     DROP TABLE IF EXISTS "casrec_csv"."table_list";
@@ -32,7 +32,7 @@ def delete_all_schemas(log, conn, ignore_schemas):
         information_schema.schemata
         WHERE
         schema_name not like 'pg_%'
-        and schema_name not in ({ignore_schemas}'public', 'information_schema');
+        and schema_name not in ({preserve_schemas}'public', 'information_schema');
     """
     cursor.execute(get_schemas_statement)
     schemas = ""

--- a/migration_steps/transform_casrec-dockerfile
+++ b/migration_steps/transform_casrec-dockerfile
@@ -4,5 +4,6 @@ RUN pip3 install -r /migration/requirements.txt
 COPY transform_casrec/transform.sh /transform_casrec/transform.sh
 COPY transform_casrec/transform /transform_casrec/transform
 COPY transform_casrec/additional_data /transform_casrec/additional_data
+COPY transform_casrec/filter_data /transform_casrec/filter_data
 COPY shared /shared
 CMD ["echo", "NO_OP"]

--- a/migration_steps/transform_casrec/filter_data/app/app.py
+++ b/migration_steps/transform_casrec/filter_data/app/app.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import time
+import psycopg2
+from config import get_config
+from dotenv import load_dotenv
+from helpers import log_title
+from db_helpers import *
+import logging
+import custom_logger
+import click
+
+env_path = current_path / "../../../../.env"
+sql_path = current_path / "sql"
+load_dotenv(dotenv_path=env_path)
+
+environment = os.environ.get("ENVIRONMENT")
+config = get_config(environment)
+
+# logging
+log = logging.getLogger("root")
+log.addHandler(custom_logger.MyHandler())
+config.custom_log_level()
+verbosity_levels = config.verbosity_levels
+
+
+def set_logging_level(verbose):
+    try:
+        log.setLevel(verbosity_levels[verbose])
+    except KeyError:
+        log.setLevel("INFO")
+        log.info(f"{verbose} is not a valid verbosity level")
+
+
+@click.command()
+@click.option("-v", "--verbose", count=True)
+@click.option("--team", default=None)
+@click.option(
+    "--clear",
+    prompt=False,
+    default=False
+)
+def main(verbose, team, clear):
+    set_logging_level(verbose)
+    log.info(log_title(message="Filter Data"))
+    conn_source = psycopg2.connect(config.get_db_connection_string("migration"))
+
+    if team:
+        team = 'T' + team
+        log.info(f"Lay Team filtering requested: Team {team}")
+        log.info(f"Deleting data not associated with {team}")
+        execute_generated_sql(
+            sql_path,
+            "delete_filtered_source_data.template.sql",
+            "{team}",
+            team,
+            conn_source,
+        )
+    else:
+        log.info(f"No filtering requested, proceed with migrating ALL.")
+
+
+
+if __name__ == "__main__":
+    t = time.process_time()
+
+    log.setLevel(1)
+    log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
+
+    main()
+
+    print(f"Total time: {round(time.process_time() - t, 2)}")

--- a/migration_steps/transform_casrec/filter_data/app/sql/delete_filtered_source_data.template.sql
+++ b/migration_steps/transform_casrec/filter_data/app/sql/delete_filtered_source_data.template.sql
@@ -1,0 +1,28 @@
+-- These are ordered!
+-- e.g. you need the pat table to construct the other queries so delete from that last
+
+-- Add to this file as we implement each entity and understand link to client caseref.
+
+-- deputy
+DELETE FROM casrec_csv.deputy WHERE "Deputy No" IN (
+    SELECT deputyship."Deputy No" FROM casrec_csv.deputyship WHERE deputyship."Case" IN (
+        SELECT casrec_csv.pat."Case" FROM casrec_csv.pat WHERE casrec_csv.pat."Lay Team" != '{team}'
+    )
+);
+SELECT COUNT(*) FROM casrec_csv.deputy;
+
+-- deputyships
+DELETE FROM casrec_csv.deputyship WHERE deputyship."Case" IN (
+    SELECT casrec_csv.pat."Case" FROM casrec_csv.pat WHERE casrec_csv.pat."Lay Team" != '{team}'
+);
+SELECT COUNT(*) FROM casrec_csv.deputyship;
+
+-- order table (cases)
+DELETE FROM casrec_csv.order
+USING casrec_csv.pat
+WHERE pat."Case" = casrec_csv.order."Case"
+AND casrec_csv.pat."Lay Team" != '{team}';
+SELECT COUNT(*) FROM casrec_csv.order;
+
+-- pat
+DELETE FROM casrec_csv.pat WHERE "Lay Team" != '{team}';

--- a/migration_steps/transform_casrec/transform.sh
+++ b/migration_steps/transform_casrec/transform.sh
@@ -2,7 +2,7 @@
 set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-
+python3 "${DIR}/filter_data/app/app.py" "$@"
 python3 "${DIR}/transform/app/app.py"  --clear=True
 python3 "${DIR}/additional_data/app/app.py"  --clear=True
 


### PR DESCRIPTION
## Purpose

Allow the person running the migration to (optionally) specify a Lay team, and then only migrate data pertinent to clients of that team

## Approach

Grappled for a while with adding a 'migrate' flag/boolean column to casrec_csv.pat and switching it, and then adding code through every step to reference this column, passing the selected Lay team args around bash... it was messy

The simplest most elegant answer was staring us in the face - delete everything we're not migrating. 

Now we don't have to add or modify any code at any of the steps in our pipeline, it all runs as it did - just on filtered (less) data.

## Learning

Got stuck into Bash a bit more than usual

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
