### PR TITLE
In 703b

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ workflows:
 
 orbs:
   aws-cli: circleci/aws-cli@1.3.0
-  slack: circleci/slack@4.1
+
   dockerhub_helper:
     orbs:
       docker: circleci/docker@1.4.0
@@ -174,6 +174,7 @@ orbs:
           - run:
               name: Install Terraform
               command: sudo unzip terraform_${TF_VERSION}_linux_amd64.zip -d /bin
+
       setup_ecs_runner:
         steps:
           - run:
@@ -192,6 +193,7 @@ orbs:
                 sudo tar -xvf $HOME/opg-ecs-helper.tar.gz -C /usr/local/bin
                 sudo chmod +x /usr/local/bin/ecs-stabilizer
                 sudo chmod +x /usr/local/bin/ecs-runner
+
   migration:
     executors:
       python:
@@ -236,6 +238,140 @@ orbs:
                 --circle_project_username "${CIRCLE_PROJECT_USERNAME}" \
                 --circle_project_reponame "${CIRCLE_PROJECT_REPONAME}"
               working_directory: ~/project/docs/ci_scripts
+  notififications:
+    orbs:
+      slack: circleci/slack@4.1
+    commands:
+      notify_env_vars:
+        steps:
+          - run:
+              name: set environment variables
+              when: always
+              command: |
+                echo "export TF_WORKSPACE=\"${TF_WORKSPACE}\"" >> $BASH_ENV
+                cd /home/circleci/project
+                COMMIT_MESSAGE=`git log --oneline -1`
+                echo "export COMMIT_MESSAGE=\"${COMMIT_MESSAGE}\"" >> $BASH_ENV
+                echo "export MENTION_USER=URHDYJ5BR" >> $BASH_ENV
+      notify_if_success:
+        steps:
+          - slack/notify:
+              channel: opg-migration-builds
+              event: pass
+              custom: |
+                {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": ":github-tick: *Build to ${ENVIRONMENT} successful*"
+                            }
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "*Branch*: ${CIRCLE_BRANCH}\n\n*Commit Message*: ${COMMIT_MESSAGE}\n\n*"
+                            }
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Kicked off by *${CIRCLE_USERNAME}*"
+                            }
+                        },
+                        {
+                            "type": "divider"
+                        },
+                        {
+                            "type": "actions",
+                            "elements": [
+                                {
+                                    "type": "button",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Go to Pull Request",
+                                        "emoji": true
+                                    },
+                                    "value": "github_pr",
+                                    "url": "${CI_PULL_REQUEST}"
+                                },
+                                {
+                                    "type": "button",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Go to Circle Job",
+                                        "emoji": true
+                                    },
+                                    "value": "circle_job",
+                                    "url": "${CIRCLE_BUILD_URL}"
+                                }
+                            ]
+                        }
+                    ]
+                }
+      notify_if_fail:
+        steps:
+          - slack/notify:
+              channel: opg-migration-builds
+              event: fail
+              custom: |
+                {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": ":x::dancebadger: *Build to ${ENVIRONMENT} failed*"
+                            }
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "*Branch*: ${CIRCLE_BRANCH}\n\n*Commit Message*: ${COMMIT_MESSAGE}\n\n*Stage Failed*: ${CIRCLE_STAGE}"
+                            }
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": "Kicked off by *${CIRCLE_USERNAME}*\n\n"
+                            }
+                        },
+                        {
+                            "type": "divider"
+                        },
+                        {
+                            "type": "actions",
+                            "elements": [
+                                {
+                                    "type": "button",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Go to Pull Request",
+                                        "emoji": true
+                                    },
+                                    "value": "github_pr",
+                                    "url": "${CI_PULL_REQUEST}"
+                                },
+                                {
+                                    "type": "button",
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Go to Circle Job",
+                                        "emoji": true
+                                    },
+                                    "value": "circle_job",
+                                    "url": "${CIRCLE_BUILD_URL}"
+                                }
+                            ]
+                        }
+                    ]
+                }
+
 jobs:
   manage_workflow:
     executor: migration/python
@@ -251,6 +387,8 @@ jobs:
       - checkout
       - migration/login_codeartifact
       - migration/cancel_redundant_builds
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
   kick_off_environment:
     executor: migration/python
     resource_class: small
@@ -288,6 +426,8 @@ jobs:
             --header "Circle-Token: ${CIRCLE_BUILDS_TOKEN}" \
             --header 'content-type: application/json' \
             --data "{\"branch\":\"master\", \"parameters\":{\"run_master\": false, \"run_preprod\": $RUN_PREPROD, \"run_qa\": $RUN_QA}}"
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
 
   tag_image_for_qa:
     executor: migration/python
@@ -337,6 +477,8 @@ jobs:
             echo ${AWS_REGISTRY}/casrec-migration/etl0:${VERSION}
             docker image ls
             docker-compose -f docker-compose.ci.yml push
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
 
   run_step_function:
     executor: migration/python
@@ -380,128 +522,9 @@ jobs:
           name: run the function
           command: python3 run_step_function.py --role sirius-ci --account ${SIRIUS_ACCOUNT} --wait_for ${WAIT_FOR} --no_reload ${NO_RELOAD} --environment ${ENVIRONMENT}
           working_directory: ~/project/docs/ci_scripts
-      - run:
-          name: set environment variables
-          command: |
-            echo "export TF_WORKSPACE=\"${TF_WORKSPACE}\"" >> $BASH_ENV
-            cd /home/circleci/project
-            COMMIT_MESSAGE=`git log --oneline -1`
-            echo "export COMMIT_MESSAGE=\"${COMMIT_MESSAGE}\"" >> $BASH_ENV
-            echo "export MENTION_USER=URHDYJ5BR" >> $BASH_ENV
-      - slack/notify:
-          custom: |
-              {
-                  "blocks": [
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": ":github-tick: *Build to ${ENVIRONMENT} successful*"
-                          }
-                      },
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": "*Branch*: ${CIRCLE_BRANCH}\n\n*Commit Message*: ${COMMIT_MESSAGE}"
-                          }
-                      },
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": "Kicked off by *${CIRCLE_USERNAME}*"
-                          }
-                      },
-                      {
-                          "type": "divider"
-                      },
-                      {
-                          "type": "actions",
-                          "elements": [
-                              {
-                                  "type": "button",
-                                  "text": {
-                                      "type": "plain_text",
-                                      "text": "Go to Pull Request",
-                                      "emoji": true
-                                  },
-                                  "value": "github_pr",
-                                  "url": "${CI_PULL_REQUEST}"
-                              },
-                              {
-                                  "type": "button",
-                                  "text": {
-                                      "type": "plain_text",
-                                      "text": "Go to Circle Job",
-                                      "emoji": true
-                                  },
-                                  "value": "circle_job",
-                                  "url": "${CIRCLE_BUILD_URL}"
-                              }
-                          ]
-                      }
-                  ]
-              }
-          channel: opg-migration-builds
-          event: pass
-      - slack/notify:
-          custom: |
-              {
-                  "blocks": [
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": ":x::dancebadger: *Build to ${ENVIRONMENT} failed*"
-                          }
-                      },
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": "*Branch*: ${CIRCLE_BRANCH}\n\n*Commit Message*: ${COMMIT_MESSAGE}"
-                          }
-                      },
-                      {
-                          "type": "section",
-                          "text": {
-                              "type": "mrkdwn",
-                              "text": "Kicked off by *${CIRCLE_USERNAME}*"
-                          }
-                      },
-                      {
-                          "type": "divider"
-                      },
-                      {
-                          "type": "actions",
-                          "elements": [
-                              {
-                                  "type": "button",
-                                  "text": {
-                                      "type": "plain_text",
-                                      "text": "Go to Pull Request",
-                                      "emoji": true
-                                  },
-                                  "value": "github_pr",
-                                  "url": "${CI_PULL_REQUEST}"
-                              },
-                              {
-                                  "type": "button",
-                                  "text": {
-                                      "type": "plain_text",
-                                      "text": "Go to Circle Job",
-                                      "emoji": true
-                                  },
-                                  "value": "circle_job",
-                                  "url": "${CIRCLE_BUILD_URL}"
-                              }
-                          ]
-                      }
-                  ]
-              }
-          channel: opg-migration-builds
-          event: fail
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
+      - notififications/notify_if_success
   run_behat_tests:
     executor: terraform/terraform
     resource_class: small
@@ -519,6 +542,8 @@ jobs:
       - run:
           name: Run behat tests
           command: ecs-runner -task behat-migration -timeout 600
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
   run_elasticsearch_reset:
     executor: terraform/terraform
     resource_class: small
@@ -536,6 +561,8 @@ jobs:
       - run:
           name: Reset Elasticsearch
           command: ecs-runner -task reset-elasticsearch -timeout 600
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
   reset_sirius:
     executor: terraform/terraform
     resource_class: small
@@ -574,6 +601,9 @@ jobs:
       - run:
           name: Reset Elasticsearch
           command: ecs-runner -task reset-elasticsearch -timeout 600
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
+
   build:
     executor: migration/python
     resource_class: small
@@ -634,6 +664,9 @@ jobs:
       - run:
           name: Push images
           command: docker-compose -f docker-compose.ci.yml push
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
+
   infrastructure:
     executor: terraform/terraform
     resource_class: small
@@ -666,6 +699,9 @@ jobs:
       - run:
           name: Output
           command: terraform output -json > terraform.output.json
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail
+
   get_latest_image:
     executor: migration/python
     resource_class: small
@@ -692,3 +728,5 @@ jobs:
           root: .
           paths:
             - VERSION
+      - notififications/notify_env_vars
+      - notififications/notify_if_fail

--- a/docs/ci_scripts/run_step_function.py
+++ b/docs/ci_scripts/run_step_function.py
@@ -5,6 +5,11 @@ import time
 import json
 from botocore.credentials import RefreshableCredentials
 from botocore.session import get_session
+from datetime import datetime, timedelta
+
+
+def to_datetime(date_string):
+    return datetime.strptime(date_string, "%Y-%m-%d %H:%M:%S.%f")
 
 
 class StepFunctionRunner:
@@ -12,15 +17,21 @@ class StepFunctionRunner:
     sts_client = ""
     region = ""
     auto_refresh_session_step_func = ""
+    auto_refresh_session_logs = ""
     sf_arn = ""
     execution_arn = ""
     wait_time = 0
+    previous_pointers = []
+    latest_timestamp = ""
 
     def __init__(self, role_name, sts_client, region):
         self.role_name = role_name
         self.sts_client = sts_client
         self.region = region
         self.wait_time = 0
+        self.latest_timestamp = datetime.fromtimestamp(
+            int((datetime.now() - timedelta(hours=12)).timestamp())
+        )
 
     def step_function_arn(self, step_function_name):
         state_machines = self.auto_refresh_session_step_func.list_state_machines()
@@ -37,6 +48,7 @@ class StepFunctionRunner:
         executions = self.auto_refresh_session_step_func.list_executions(
             stateMachineArn=self.sf_arn, statusFilter="RUNNING"
         )
+        self.print_from_logs()
         if len(executions["executions"]) > 0 and self.wait_time < wait_for:
             time.sleep(secs)
             self.wait_time += secs
@@ -47,6 +59,50 @@ class StepFunctionRunner:
             os._exit()
         else:
             print("Ready to run step function")
+
+    def print_from_logs(self):
+        query = (
+            "fields @timestamp, @logStream, @message | sort @timestamp asc | limit 2000"
+        )
+        log_group = "casrec-migration-development"
+
+        start_time = int((datetime.now() - timedelta(minutes=5)).timestamp())
+        end_time = int((datetime.today() + timedelta(days=1)).timestamp())
+
+        start_query_response = self.auto_refresh_session_logs.start_query(
+            logGroupName=log_group,
+            startTime=start_time,
+            endTime=end_time,
+            queryString=query,
+        )
+        query_id = start_query_response["queryId"]
+        time.sleep(1)
+        response = self.auto_refresh_session_logs.get_query_results(queryId=query_id)
+
+        log_records = []
+        for fields in response["results"]:
+            if (
+                (fields[0]["field"] == "@timestamp")
+                and (to_datetime(fields[0]["value"]) >= self.latest_timestamp)
+                and (fields[3]["value"] not in self.previous_pointers)
+            ):
+                log_record = {
+                    "timestamp": fields[0]["value"],
+                    "logStream": fields[1]["value"],
+                    "message": fields[2]["value"],
+                    "ptr": fields[3]["value"],
+                }
+                log_records.append(log_record)
+                self.latest_timestamp = to_datetime(log_record["timestamp"])
+
+        for log_record in log_records:
+            print(
+                f"{log_record['timestamp']} - {log_record['logStream']}: {log_record['message']}"
+            )
+        if len(log_records) > 0:
+            self.previous_pointers = []
+            for ptr in log_records:
+                self.previous_pointers.append(ptr["ptr"])
 
     def run_step_function(self, no_reload):
         if no_reload == "true":
@@ -103,7 +159,7 @@ class StepFunctionRunner:
         }
         return credentials
 
-    def create_session(self):
+    def create_session_step(self):
         session_credentials = RefreshableCredentials.create_from_metadata(
             metadata=self.refresh_creds(),
             refresh_using=self.refresh_creds,
@@ -115,6 +171,20 @@ class StepFunctionRunner:
         autorefresh_session = boto3.Session(botocore_session=session)
         self.auto_refresh_session_step_func = autorefresh_session.client(
             "stepfunctions", region_name=self.region
+        )
+
+    def create_session_logs(self):
+        session_credentials = RefreshableCredentials.create_from_metadata(
+            metadata=self.refresh_creds(),
+            refresh_using=self.refresh_creds,
+            method="sts-assume-role",
+        )
+        session = get_session()
+        session._credentials = session_credentials
+        session.set_config_variable("region", self.region)
+        autorefresh_session = boto3.Session(botocore_session=session)
+        self.auto_refresh_session_logs = autorefresh_session.client(
+            "logs", region_name=self.region
         )
 
 
@@ -132,7 +202,8 @@ def main(role, account, wait_for, no_reload, environment):
 
     step_function_runner = StepFunctionRunner(role_to_assume, base_client, region)
 
-    step_function_runner.create_session()
+    step_function_runner.create_session_step()
+    step_function_runner.create_session_logs()
     step_function_runner.step_function_arn(sf_name)
     step_function_runner.step_function_running_wait_for(int(wait_for))
     response = step_function_runner.run_step_function(no_reload)


### PR DESCRIPTION
## Purpose

We didn't have logging for the step function bit in our circle job. This PR polls cloudwatch and brings the logs in.

Also so that we could have a badger waving (and other reasons), we couldn't do global notifications to slack. Unfornately the bespoke notifications are on a per job basis so i had just stuck them on step function before. Now i've added the fail ones everywhere and success on step function so we get to see the badger no matter which step we break! yay. 

## Approach

Poll cloudwatch. Do semi clever stuff with timestamps and transaction ids to get unique order log records...

## Learning

NA
## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
