### PR TITLE
IN-766 make entities selectable from parameter store

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,14 @@ orbs:
               working_directory: ~/project
       notify_if_success:
         steps:
+          - run:
+              name: set entities environment variables
+              when: always
+              command: |
+                python3 get_environment_entities.py --environment ${TF_WORKSPACE} --role integrations-ci >> ENTITIES
+                ENTITIES=$(cat ENTITIES)
+                echo "export ENTITIES=\"${ENTITIES}\"" >> $BASH_ENV
+              working_directory: ~/project/docs/ci_scripts
           - slack/notify:
               channel: opg-migration-builds
               event: pass
@@ -358,14 +366,14 @@ orbs:
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": "*Branch*: ${CIRCLE_BRANCH}\n\n*Commit Message*: ${COMMIT_MESSAGE}\n\n*"
+                                "text": "*Branch*: ${CIRCLE_BRANCH}\n\n*Commit Message*: ${COMMIT_MESSAGE}\n\n"
                             }
                         },
                         {
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": "Kicked off by *${CIRCLE_USERNAME}*"
+                                "text": "*Kicked off by:* ${CIRCLE_USERNAME}\n\n*Entities*: ${ENTITIES}\n"
                             }
                         },
                         {

--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ Get the tag of the ECR task you want to run. This is generally the commit tag. Y
 
 ```
 aws-vault exec identity -- docker-compose -f docker-compose.commands.yml run --rm task_runner ./run_ecs_task.sh \
--t master-bf3f623 \
+-t ecr-tag-you-want-to-use \
 -i validation \
 -n etl5 \
 -c "validation/api_tests.sh" \

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Another example of running a task (this one uploads the fees to preprod):
 
 ```
 aws-vault exec identity -- docker-compose -f docker-compose.commands.yml run --rm task_runner ./run_ecs_task.sh \
--t jimmytest \
+-t ecr-tag-you-want-to-use \
 -i load-casrec \
 -n etl1 \
 -c python3,load_fees/app/app.py \

--- a/docker-compose.override.ci.yml
+++ b/docker-compose.override.ci.yml
@@ -17,7 +17,5 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
-      ENVIRONMENT: development
-      ACCOUNT_NAME: development
       CI: $CI
       SIRIUS_ACCOUNT: 288342028542

--- a/docs/ci_scripts/get_environment_entities.py
+++ b/docs/ci_scripts/get_environment_entities.py
@@ -1,0 +1,37 @@
+import boto3
+import click
+
+
+def assume_aws_session(account, role):
+    """
+    Assume an AWS session so that we can access AWS resources as that account
+    """
+
+    client = boto3.client("sts")
+    role_to_assume = f"arn:aws:iam::{account}:role/{role}"
+    response = client.assume_role(
+        RoleArn=role_to_assume, RoleSessionName="assumed_role"
+    )
+
+    session = boto3.Session(
+        aws_access_key_id=response["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+        aws_session_token=response["Credentials"]["SessionToken"],
+    )
+
+    return session
+
+
+@click.command()
+@click.option("--role", default="operator")
+@click.option("--environment", default="development")
+def main(role, environment):
+    account = {"development": "288342028542", "preproduction": "492687888235"}
+    session = assume_aws_session(account[environment], role)
+    ssm = session.client("ssm", region_name="eu-west-1")
+    parameter = ssm.get_parameter(Name=f"{environment}-allowed-entities")
+    print(parameter["Parameter"]["Value"])
+
+
+if __name__ == "__main__":
+    main()

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import boto3
 from pathlib import Path
 from deprecated import deprecated
 from dotenv import load_dotenv
@@ -9,6 +10,14 @@ def load_env_vars():
     current_path = Path(os.path.dirname(os.path.realpath(__file__)))
     env_path = current_path / "../.env"
     load_dotenv(dotenv_path=env_path)
+
+
+def get_enabled_entities_from_param_store(env):
+    session = boto3.session.Session()
+    ssm = session.client("ssm", region_name="eu-west-1")
+    parameter = ssm.get_parameter(Name=f"{env}-allowed-entities")
+
+    return parameter["Parameter"]["Value"].split(",")
 
 
 class BaseConfig:
@@ -64,26 +73,28 @@ class BaseConfig:
 
     DEFAULT_CHUNK_SIZE = 20000
 
-    ALL_ENVIRONMENTS = ["local", "development", "preproduction", "qa"]
+    ALL_ENVIRONMENTS = ["local", "development"]
     ENABLED_ENTITIES = {
-        "clients": ["local", "development", "preproduction"],
-        "cases": ["local", "development", "preproduction"],
-        "bonds": ["local", "development", "preproduction"],
-        "supervision_level": ["local", "development", "preproduction"],
-        "deputies": ["local", "development", "preproduction"],
+        "clients": ["local", "development"],
+        "cases": ["local", "development"],
+        "bonds": ["local", "development"],
+        "supervision_level": ["local", "development"],
+        "deputies": ["local", "development"],
         "finance": [],
-        "remarks": ["local", "development", "preproduction"],
+        "remarks": ["local", "development"],
         "reporting": [],
         "tasks": [],
         "visits": [],
-        "warnings": ["local", "development", "preproduction"],
+        "warnings": ["local", "development"],
         "additional_data": [],
-        "death": ["local", "development", "preproduction"],
+        "death": ["local", "development"],
     }
 
     def allowed_entities(self, env):
-
-        return [k for k, v in self.ENABLED_ENTITIES.items() if env in v]
+        if env in ["development", "preproduction", "qa", "production"]:
+            return get_enabled_entities_from_param_store(env)
+        else:
+            return [k for k, v in self.ENABLED_ENTITIES.items() if env in v]
 
 
 class LocalConfig(BaseConfig):

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -73,7 +73,7 @@ class BaseConfig:
 
     DEFAULT_CHUNK_SIZE = 20000
 
-    ALL_ENVIRONMENTS = ["local", "development"]
+    ALL_ENVIRONMENTS = ["local", "development", "preproduction", "qa"]
     ENABLED_ENTITIES = {
         "clients": ["local", "development"],
         "cases": ["local", "development"],
@@ -91,7 +91,7 @@ class BaseConfig:
     }
 
     def allowed_entities(self, env):
-        if env in ["development", "preproduction", "qa", "production"]:
+        if env in ["preproduction", "qa", "production"]:
             return get_enabled_entities_from_param_store(env)
         else:
             return [k for k, v in self.ENABLED_ENTITIES.items() if env in v]

--- a/migration_steps/transform_casrec/transform/app/app.py
+++ b/migration_steps/transform_casrec/transform/app/app.py
@@ -109,6 +109,7 @@ def main(clear, team, chunk_size):
 
     db_config["chunk_size"] = chunk_size if chunk_size else 10000
     log.info(f"Chunking data at {chunk_size} rows")
+
     print(f"allowed_entities: {allowed_entities}")
 
     if clear:

--- a/migration_steps/validation/api_test_data_s3_upload/app/app.py
+++ b/migration_steps/validation/api_test_data_s3_upload/app/app.py
@@ -20,13 +20,13 @@ csv_path = current_path / "csvs"
 responses_path = current_path / "responses"
 load_dotenv(dotenv_path=env_path)
 
-environment = os.environ.get("ENVIRONMENT")
+ci = os.getenv("CI")
+environment = "development" if ci == "True" else os.environ["ENVIRONMENT"]
+account = "development" if ci == "True" else os.environ["SIRIUS_ACCOUNT"]
 config = get_config(environment)
 
 session = boto3.session.Session()
 host = os.environ.get("DB_HOST")
-ci = os.getenv("CI")
-account = os.environ["SIRIUS_ACCOUNT"]
 account_name = os.environ.get("ACCOUNT_NAME")
 bucket_name = f"casrec-migration-{account_name.lower()}"
 

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "task_role_assume_policy" {
   }
 }
 
-data "aws_iam_policy_document" "ecs_task_s3" {
+data "aws_iam_policy_document" "etl_task" {
   statement {
     effect    = "Allow"
     resources = ["*"]
@@ -88,11 +88,19 @@ data "aws_iam_policy_document" "ecs_task_s3" {
       "s3:PutObjectAcl"
     ]
   }
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "ssm:GetParameters"
+    ]
+  }
 }
 
-resource "aws_iam_role_policy" "etl_task_s3" {
+resource "aws_iam_role_policy" "etl_task" {
   name   = "casrec-migration-task-logs.${local.environment}"
-  policy = data.aws_iam_policy_document.ecs_task_s3.json
+  policy = data.aws_iam_policy_document.etl_task.json
   role   = aws_iam_role.etl.id
 }
 

--- a/terraform/parameter_store.tf
+++ b/terraform/parameter_store.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_parameter" "allowed_entities" {
+  name  = "${local.account.name}-allowed-entities"
+  type  = "String"
+  value = "client"
+
+  tags = local.default_tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
## Purpose

Put entities as comma separate list (no spaces) in parameter store. Bring them in, convert to list and use them for preproduction, qa and prod environments.

## Approach

Nothing too tricky here. Was just a bit of fun with some of the env vars in CI that needed some tweaking...

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
