### PR TITLE
Remarks Casenotes DB validation

### DIFF
--- a/migration_steps/shared/mapping_definitions/notes_mapping.json
+++ b/migration_steps/shared/mapping_definitions/notes_mapping.json
@@ -76,7 +76,7 @@
     },
     "type": {
         "mapping_status": {
-            "is_complete": false
+            "is_complete": true
         },
         "sirius_details": {
             "is_pk": "",
@@ -126,7 +126,7 @@
     },
     "description": {
         "mapping_status": {
-            "is_complete": false
+            "is_complete": true
         },
         "sirius_details": {
             "is_pk": "",
@@ -176,7 +176,7 @@
     },
     "createdtime": {
         "mapping_status": {
-            "is_complete": false
+            "is_complete": true
         },
         "sirius_details": {
             "is_pk": "",
@@ -226,7 +226,7 @@
     },
     "upload_id": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",
@@ -251,7 +251,7 @@
     },
     "document_id": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",
@@ -276,7 +276,7 @@
     },
     "direction": {
         "mapping_status": {
-            "is_complete": false
+            "is_complete": true
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -518,6 +518,44 @@
             ]
         }
     },
+    "notes": {
+        "exclude": [
+            "createdtime",
+            "upload_id",
+            "document_id"
+        ],
+        "forced": {
+            "caserecnumber": {
+                "mapping_table": "client_persons.caserecnumber"
+            },
+            "createdtime": {
+                "casrec": "CAST(CONCAT(remarks.\"Logdate\", ' ', LEFT(remarks.\"Logtime\", 8)) AS TIMESTAMP(0))",
+                "sirius": "notes.createdtime"
+            }
+        },
+        "orderby": {},
+        "casrec": {
+            "from_table": "remarks",
+            "joins": [
+                "LEFT JOIN casrec_csv.pat ON casrec_csv.pat.\"Case\" = casrec_csv.remarks.\"Case\""
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_notes exc_table ON exc_table.caserecnumber = pat.\"Case\"",
+            "where_clauses": []
+        },
+        "sirius": {
+            "from_table": "caseitem_note",
+            "joins": [
+                "LEFT JOIN {target_schema}.cases ON cases.id = caseitem_note.caseitem_id",
+                "LEFT JOIN {target_schema}.notes ON notes.id = caseitem_note.note_id",
+                "LEFT JOIN {target_schema}.persons ON persons.id = cases.client_id"
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_notes exc_table ON exc_table.caserecnumber = persons.caserecnumber",
+            "where_clauses": [
+                "persons.type = 'actor_client'",
+                "persons.clientsource = 'CASRECMIGRATION'"
+            ]
+        }
+    },
     "supervision_level_log": {
         "exclude": [
             "order_id"

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -70,6 +70,7 @@ def get_mappings():
             "deputy_special_warnings",
             "deputy_violent_warnings",
         ],
+        "remarks": ["notes"]
     }
 
     for entity, mapping in all_mappings.items():


### PR DESCRIPTION
## Purpose

Provides validation at a data(base) level for the migrated remarks entity

## Approach

Same approach as the other entities: one SELECT statement picks the rows we are migrating from the casrec remarks table - another SELECT statement pics the corresponding rows from the target table (in this case, public.notes), and the two queries are compared using an EXCEPT statement which returns only the differences. These differences are then inserted into an 'exceptions' table for the entity, which we can refer back to later

Then, a second pass attempts to provide more context to the exceptions - testing each column in turn to try and identify which column/field failed - this is then saved alongside the failed row

## Learning

This particular validation has highlighted a fair few inconsistencies with the remarks entity, which I'll raise bug tickets for.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
