### PR TITLE
IN-775 preprod datatypes fix

### DIFF
--- a/migration_steps/transform_casrec/transform/app/utilities/db_insert.py
+++ b/migration_steps/transform_casrec/transform/app/utilities/db_insert.py
@@ -46,12 +46,12 @@ class InsertData:
 
         columns = []
         for col, details in mapping_details.items():
-            details["data_type"] = (
+            details["remapped_data_type"] = (
                 self.datatype_remap[details["data_type"].lower()]
                 if details["data_type"] in self.datatype_remap
                 else details["data_type"]
             )
-            columns.append(f"{col} {details['data_type']}")
+            columns.append(f"{col} {details['remapped_data_type']}")
 
         try:
             columns_from_df = self._list_table_columns(df=df)


### PR DESCRIPTION
I was accidentally remapping the actual datatype in the mapping dict, which was fine locally because the total number of rows was less than the chunk size. 
However on preprod when it got to chunk 2 of `addresses.address_lines` (would have happened to any field that had the datatype remapped from something pandas-friendly to something sql-friendly, this was just the first one) then the datatype had been remapped from `dict` to `json` which makes no sense to Pandas, so it crashed.