### PR TITLE
IN-768 mark closed_by as unmapped as per spreadsheet

### DIFF
--- a/migration_steps/shared/mapping_definitions/client_nodebtchase_warnings_mapping.json
+++ b/migration_steps/shared/mapping_definitions/client_nodebtchase_warnings_mapping.json
@@ -51,7 +51,7 @@
     },
     "closed_by": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/mapping_definitions/client_saarcheck_warnings_mapping.json
+++ b/migration_steps/shared/mapping_definitions/client_saarcheck_warnings_mapping.json
@@ -51,7 +51,7 @@
     },
     "closed_by": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/mapping_definitions/client_special_warnings_mapping.json
+++ b/migration_steps/shared/mapping_definitions/client_special_warnings_mapping.json
@@ -51,7 +51,7 @@
     },
     "closed_by": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/mapping_definitions/client_violent_warnings_mapping.json
+++ b/migration_steps/shared/mapping_definitions/client_violent_warnings_mapping.json
@@ -51,7 +51,7 @@
     },
     "closed_by": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/mapping_definitions/deputy_special_warnings_mapping.json
+++ b/migration_steps/shared/mapping_definitions/deputy_special_warnings_mapping.json
@@ -51,7 +51,7 @@
     },
     "closed_by": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/mapping_definitions/deputy_violent_warnings_mapping.json
+++ b/migration_steps/shared/mapping_definitions/deputy_violent_warnings_mapping.json
@@ -51,7 +51,7 @@
     },
     "closed_by": {
         "mapping_status": {
-            "is_complete": true
+            "is_complete": false
         },
         "sirius_details": {
             "is_pk": "",

--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -151,7 +151,7 @@
         }
     },
     "client_nodebtchase_warnings": {
-        "exclude": ["closed_by"],
+        "exclude": [],
         "forced": {
             "caserecnumber": {
                 "mapping_table": "client_persons.caserecnumber"
@@ -239,7 +239,7 @@
         }
     },
     "client_saarcheck_warnings": {
-        "exclude": ["closed_by"],
+        "exclude": [],
         "forced": {
             "caserecnumber": {
                 "mapping_table": "client_persons.caserecnumber"
@@ -270,7 +270,7 @@
         }
     },
     "client_special_warnings": {
-        "exclude": ["closed_by"],
+        "exclude": [],
         "forced": {
             "caserecnumber": {
                 "mapping_table": "client_persons.caserecnumber"
@@ -301,7 +301,7 @@
         }
     },
     "client_violent_warnings": {
-        "exclude": ["closed_by"],
+        "exclude": [],
         "forced": {
             "caserecnumber": {
                 "mapping_table": "client_persons.caserecnumber"
@@ -428,7 +428,7 @@
         }
     },
     "deputy_special_warnings": {
-        "exclude": ["closed_by"],
+        "exclude": [],
         "forced": {
             "caserecnumber": {
                 "mapping_table": "cases.caserecnumber"
@@ -473,7 +473,7 @@
         }
     },
     "deputy_violent_warnings": {
-        "exclude": ["closed_by"],
+        "exclude": [],
         "forced": {
             "caserecnumber": {
                 "mapping_table": "cases.caserecnumber"


### PR DESCRIPTION
## Purpose

_Briefly describe the purpose of the change, and/or link to the ticket for context_

## Approach

The answer to this was not to exclude closed_by from validation but to mark the whole field in the mapping file as is_complete = false, as it is marked as unmapped in the spreadsheet.

I've made the changes in this repo and when the mapping files are next regenerated they should be the same.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
