### PR TITLE
IN-795 team 2 errors

### DIFF
--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from deprecated import deprecated
 from dotenv import load_dotenv
 
+log = logging.getLogger("root")
+
 
 def load_env_vars():
     current_path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -93,9 +95,17 @@ class BaseConfig:
 
     def allowed_entities(self, env):
         if env in ["preproduction", "qa", "production"]:
-            return get_enabled_entities_from_param_store(env)
+            enabled_entity_list = get_enabled_entities_from_param_store(env)
         else:
-            return [k for k, v in self.ENABLED_ENTITIES.items() if env in v]
+            enabled_entity_list = [
+                k for k, v in self.ENABLED_ENTITIES.items() if env in v
+            ]
+
+        if len(enabled_entity_list) > 0:
+            return enabled_entity_list
+        else:
+            log.error("No entities enabled")
+            os._exit(1)
 
 
 class LocalConfig(BaseConfig):

--- a/migration_steps/shared/quick_validation/dev_row_counts.json
+++ b/migration_steps/shared/quick_validation/dev_row_counts.json
@@ -89,14 +89,16 @@
         "table_name": "notes",
         "query": "select count(*) from {schema}.notes;",
         "row_counts": {
-          "all": 54672
+          "all": 54672,
+          "team_2": 0
         }
       },
       {
         "table_name": "caseitem_note",
         "query": "select count(*) from {schema}.caseitem_note;",
         "row_counts": {
-          "all": 132632
+          "all": 132632,
+          "team_2": 0
         },
         "note": "not sure this is right - double check using source data"
       }
@@ -108,7 +110,8 @@
         "table_name": "supervision_level_log",
         "query": "select count(*) from {schema}.supervision_level_log;",
         "row_counts": {
-          "all": 1832
+          "all": 1832,
+          "team_2": 0
         }
       }
     ]

--- a/migration_steps/transform_casrec/transform/app/entities/crec/persons.py
+++ b/migration_steps/transform_casrec/transform/app/entities/crec/persons.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 
 from helpers import get_mapping_dict
+from transform_data.apply_datatypes import reapply_datatypes_to_fk_cols
 
 log = logging.getLogger("root")
 
@@ -63,7 +64,9 @@ def insert_persons_crec(db_config, target_db):
 
             crec_joined_df = crec_joined_df.rename(columns={"id_persons": "id"})
 
-            # print(crec_joined_df.sample(10).to_markdown())
+            crec_joined_df = reapply_datatypes_to_fk_cols(
+                columns=["id"], df=crec_joined_df
+            )
 
             fields_to_update = [
                 x

--- a/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_logs.py
+++ b/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_logs.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 
 from helpers import get_mapping_dict
+from transform_data.apply_datatypes import reapply_datatypes_to_fk_cols
 
 log = logging.getLogger("root")
 
@@ -48,7 +49,7 @@ def insert_annual_report_logs(db_config, target_db):
 
             annual_report_log_joined_df = annual_report_log_df.merge(
                 persons_df,
-                how="left",
+                how="inner",
                 left_on="c_case",
                 right_on="caserecnumber",
             )
@@ -61,6 +62,10 @@ def insert_annual_report_logs(db_config, target_db):
             )
             annual_report_log_joined_df = annual_report_log_joined_df.rename(
                 columns={"id_x": "id"}
+            )
+
+            annual_report_log_joined_df = reapply_datatypes_to_fk_cols(
+                columns=["client_id"], df=annual_report_log_joined_df
             )
 
             if len(annual_report_log_joined_df) > 0:

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_person_warning.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_person_warning.py
@@ -33,16 +33,18 @@ def insert_client_person_warning(db_config, target_db):
         )
         clients_df = pd.read_sql_query(clients_query, db_config["db_connection_string"])
 
-        client_warning_query = (
-            f'select "id", "c_case" from {db_config["target_schema"]}.warnings;'
-        )
+        client_warning_query = f'select * from {db_config["target_schema"]}.warnings;'
         client_warning_df = pd.read_sql_query(
             client_warning_query, db_config["db_connection_string"]
         )
+        if len(client_warning_df) == 0:
+            raise EmptyDataFrame
+
+        client_warning_df = client_warning_df[["id", "c_case"]]
 
         client_warning_df = client_warning_df.merge(
             clients_df,
-            how="left",
+            how="inner",
             left_on="c_case",
             right_on="caserecnumber",
             suffixes=["_warning", "_client"],

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_person_warning.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_person_warning.py
@@ -35,11 +35,16 @@ def insert_deputy_person_warning(db_config, target_db):
         deputys_df = pd.read_sql_query(deputys_query, db_config["db_connection_string"])
 
         deputy_warning_query = f"""
-                select "id", "c_deputy_no" from {db_config["target_schema"]}.warnings
+                select * from {db_config["target_schema"]}.warnings
                 where casrec_mapping_file_name = 'deputy_violent_warnings_mapping';"""
         deputy_warning_df = pd.read_sql_query(
             deputy_warning_query, db_config["db_connection_string"]
         )
+
+        if len(deputy_warning_df) == 0:
+            raise EmptyDataFrame
+
+        deputy_warning_df = deputy_warning_df[["id", "c_deputy_no"]]
 
         deputy_warning_df = deputy_warning_df.merge(
             deputys_df,

--- a/migration_steps/transform_casrec/transform/app/transform_data/apply_conditions.py
+++ b/migration_steps/transform_casrec/transform/app/transform_data/apply_conditions.py
@@ -129,7 +129,9 @@ def remove_empty_rows(df, not_null_cols, how="all"):
     except Exception as e:
         log.debug(f"Problems removing null rows: {e}")
 
-    log.log(config.VERBOSE, f"Dataframe size after removing empty rows: {len(df)}")
+    log.log(
+        config.VERBOSE, f"Dataframe size after removing empty rows: {len(final_df)}"
+    )
 
     if len(final_df) == 0:
         raise EmptyDataFrame


### PR DESCRIPTION
1. reporting gave a datatype error because `client_id` was null and an int cannot be null
   - changed to an inner join so I'm not migrating any reporting records that do not have a `client_id`
   - also added the `reapply_datatypes_to_fk_cols` to make sure `client_id` is an int
2. same issue with crec
   - same fix as above
3. persons_warning once again a problem, because this team has no warning records
   - put in a check to see if the `warnings` table is empty and if so, bypass the data and just create the empty table 
4. snuck in a cheeky entity check to kill it if no entities are enabled (IN-747)