### PR TITLE
IN-784 convert empty string to NULL even if from lookup

### DIFF
--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -220,7 +220,6 @@ def wrap_casrec_col(mapped_item_key: str, col, col_definition):
     datatype = col_definition["sirius_details"]["data_type"]
     if (
         datatype not in ["bool", "int"]
-        and col_definition["transform_casrec"]["lookup_table"] == ""
     ):
         col = f"NULLIF(TRIM({col}), '')"
 


### PR DESCRIPTION
## Purpose

IN-784 investigate and fix 3 exceptions on client_persons.clientaccommodation

## Approach

The following three values in accommodation_type_lookup return an empty string:

RCH
RH
LAH

This is being migrated as NULL in Sirius. 
'' !== NULL, but this is no doubt the desired behaviour, so validation has been adjusted to pass

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
