### PR TITLE
IN-798 ignore pandas date errors

### DIFF
--- a/migration_steps/transform_casrec/transform/app/transform_data/apply_datatypes.py
+++ b/migration_steps/transform_casrec/transform/app/transform_data/apply_datatypes.py
@@ -30,12 +30,17 @@ def apply_datatypes(mapping_details: Dict, df: pd.DataFrame) -> pd.DataFrame:
         if k in df.columns
     }
 
-    try:
-        result_df = df.astype({k: v for k, v in cols_with_datatype.items()})
-        return result_df
-    except Exception as e:
-        log.error(f"Error applying datatypes: {e}")
-        os._exit(1)
+    for col, datatype in cols_with_datatype.items():
+        try:
+            if datatype == "datetime64[ns]":
+                df[col] = pd.to_datetime(df[col], errors="ignore")
+            else:
+                df[col] = df[col].astype(datatype)
+        except Exception as e:
+            log.error(f"Error converting {col} to datatype {datatype}: {e}")
+            os._exit(1)
+
+    return df
 
 
 def reapply_datatypes_to_fk_cols(columns, df):


### PR DESCRIPTION
Pandas is picky about dates, it will not let me convert anything before 1677 and after 2262.
Yeh it's probably true that any dates outside that range are wrong, but our policy of non-interference means we don't want to be going around 'correcting' Casrec data so we want to migrate it anyway. Leave pandas to its own devices and it will put NaT in there instead which is even wronger.