### PR TITLE
IN-804 added feature flag

### DIFF
--- a/migration_steps/integration/business_rules/app/app.py
+++ b/migration_steps/integration/business_rules/app/app.py
@@ -70,6 +70,11 @@ def main(clear, team):
         )
     )
     log.info(log_title(message=f"Enabled entities: {', '.join(allowed_entities)}"))
+    log.info(
+        log_title(
+            message=f"Enabled features: {', '.join(config.enabled_feature_flags(env=os.environ.get('ENVIRONMENT')))}"
+        )
+    )
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
 
     if clear:

--- a/migration_steps/integration/load_to_staging/app/app.py
+++ b/migration_steps/integration/load_to_staging/app/app.py
@@ -59,15 +59,13 @@ allowed_entities = config.allowed_entities(env=os.environ.get("ENVIRONMENT"))
 tables_list = table_helpers.get_table_list(table_helpers.get_table_file())
 
 enabled_tables = table_helpers.get_enabled_table_details()
-if "additional_data" not in allowed_entities:
-
-    log.info("additional_data entity not enabled, exiting")
-    enabled_extra_tables = {}
-
-else:
+if "additional_data" in config.enabled_feature_flags(env=environment):
     enabled_extra_tables = table_helpers.get_enabled_table_details(
         file_name="additional_data_tables"
     )
+else:
+    enabled_extra_tables = {}
+
 
 all_enabled_tables = {**enabled_tables, **enabled_extra_tables}
 
@@ -126,6 +124,11 @@ def main(clear, team):
         )
     )
     log.info(log_title(message=f"Enabled entities: {', '.join(allowed_entities)}"))
+    log.info(
+        log_title(
+            message=f"Enabled features: {', '.join(config.enabled_feature_flags(env=os.environ.get('ENVIRONMENT')))}"
+        )
+    )
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
 
     work = [base_data, inserts]

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -93,11 +93,12 @@ class BaseConfig:
     }
 
     DEV_FEATURE_FLAGS = {"match_existing_data": True, "additional_data": False}
+    QA_FEATURE_FLAGS = {"match_existing_data": False, "additional_data": False}
 
     def enabled_feature_flags(self, env):
 
         if env in ["qa", "production"]:
-            return [k for k, v in self.DEV_FEATURE_FLAGS.items() if v is True]
+            return [k for k, v in self.QA_FEATURE_FLAGS.items() if v is True]
         else:
             return [k for k, v in self.DEV_FEATURE_FLAGS.items() if v is True]
 

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -97,7 +97,7 @@ class BaseConfig:
 
     def enabled_feature_flags(self, env):
 
-        if env in ["qa", "production"]:
+        if env in ["preproduction", "qa", "production"]:
             return [k for k, v in self.QA_FEATURE_FLAGS.items() if v is True]
         else:
             return [k for k, v in self.DEV_FEATURE_FLAGS.items() if v is True]

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -89,9 +89,17 @@ class BaseConfig:
         "tasks": [],
         "visits": ["local", "development"],
         "warnings": ["local", "development"],
-        "additional_data": [],
         "death": ["local", "development"],
     }
+
+    DEV_FEATURE_FLAGS = {"match_existing_data": True, "additional_data": False}
+
+    def enabled_feature_flags(self, env):
+
+        if env in ["qa", "production"]:
+            return [k for k, v in self.DEV_FEATURE_FLAGS.items() if v is True]
+        else:
+            return [k for k, v in self.DEV_FEATURE_FLAGS.items() if v is True]
 
     def allowed_entities(self, env):
         if env in ["preproduction", "qa", "production"]:

--- a/migration_steps/transform_casrec/additional_data/app/app.py
+++ b/migration_steps/transform_casrec/additional_data/app/app.py
@@ -69,6 +69,11 @@ def main(clear):
         )
     )
     log.info(log_title(message=f"Enabled entities: {', '.join(allowed_entities)}"))
+    log.info(
+        log_title(
+            message=f"Enabled features: {', '.join(config.enabled_feature_flags(env=os.environ.get('ENVIRONMENT')))}"
+        )
+    )
 
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
     version_details = helpers.get_json_version()
@@ -76,8 +81,7 @@ def main(clear):
         f"Using JSON def version '{version_details['version_id']}' last updated {version_details['last_modified']}"
     )
 
-    if "additional_data" not in allowed_entities:
-
+    if "additional_data" not in config.enabled_feature_flags(env=environment):
         log.info("additional_data entity not enabled, exiting")
         return False
 

--- a/migration_steps/transform_casrec/transform/app/app.py
+++ b/migration_steps/transform_casrec/transform/app/app.py
@@ -101,6 +101,11 @@ def main(clear, team, chunk_size):
         )
     )
     log.info(log_title(message=f"Enabled entities: {', '.join(allowed_entities)}"))
+    log.info(
+        log_title(
+            message=f"Enabled features: {', '.join(config.enabled_feature_flags(env=os.environ.get('ENVIRONMENT')))}"
+        )
+    )
     log.debug(f"Working in environment: {os.environ.get('ENVIRONMENT')}")
     version_details = helpers.get_json_version()
     log.info(


### PR DESCRIPTION
Added a little feature flag mechanism to `config`. Used the same format as the `enabled_entities` so if we want to use param store for the 'real' data we can use the same pattern easily enough. 
Added `additional_data` in there too as that was sort of hacked in as an entity, this is better.

~Currently it's ON for preprod, because I have a data issue to debug so can't turn it off~
No longer true. I turned it OFF for preprod so I don't have to speed-fix the data issue before tonight's run.
![image](https://user-images.githubusercontent.com/6086996/127520496-4f4fdbec-d5bf-42d4-b9bc-2a9819a10f1a.png)


~Literally followed [GitHub's markdown instructions](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) to do a strikethrough above and it didn't work 😞~
Figured out how to do a strikethrough 