### PR TITLE
IN-743 validation protection for Deputy phonenumbers

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -336,6 +336,94 @@
             ]
         }
     },
+    "deputy_daytime_phonenumbers": {
+        "exclude": [
+            "person_id"
+        ],
+        "casenumber_source": "cases.caserecnumber",
+        "orderby": {
+            "casesubtype": {
+                "mapping_table": "cases.casesubtype",
+                "direction": "ASC"
+            },
+            "orderdate": {
+                "mapping_table": "cases.orderdate",
+                "direction": "ASC"
+            }
+        },
+        "casrec": {
+            "from_table": "deputyship",
+            "transform": {},
+            "joins": [
+                "LEFT JOIN casrec_csv.order ON casrec_csv.order.\"Order No\" = casrec_csv.deputyship.\"Order No\"",
+                "LEFT JOIN casrec_csv.deputy ON casrec_csv.deputyship.\"Deputy No\" = casrec_csv.deputy.\"Deputy No\""
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_daytime_phonenumbers exc_table ON exc_table.caserecnumber = casrec_csv.order.\"Case\"",
+            "where_clauses": []
+        },
+        "sirius": {
+            "from_table": "order_deputy",
+            "transform": {
+                "orderdate": "to_char({col}, 'YYYY-MM-DD')",
+                "updateddate": "to_char({col}, 'YYYY-MM-DD')"
+            },
+            "joins": [
+                "LEFT JOIN {target_schema}.cases ON cases.id = order_deputy.order_id",
+                "LEFT JOIN {target_schema}.persons ON persons.id = order_deputy.deputy_id",
+                "LEFT JOIN {target_schema}.phonenumbers ON phonenumbers.person_id = persons.id"
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_daytime_phonenumbers exc_table ON exc_table.caserecnumber = persons.caserecnumber",
+            "where_clauses": [
+                "persons.type = 'actor_deputy'",
+                "persons.clientsource = 'CASRECMIGRATION'",
+                "phonenumbers.type = 'Work'"
+            ]
+        }
+    },
+    "deputy_evening_phonenumbers": {
+        "exclude": [
+            "person_id"
+        ],
+        "casenumber_source": "cases.caserecnumber",
+        "orderby": {
+            "casesubtype": {
+                "mapping_table": "cases.casesubtype",
+                "direction": "ASC"
+            },
+            "orderdate": {
+                "mapping_table": "cases.orderdate",
+                "direction": "ASC"
+            }
+        },
+        "casrec": {
+            "from_table": "deputyship",
+            "transform": {},
+            "joins": [
+                "LEFT JOIN casrec_csv.order ON casrec_csv.order.\"Order No\" = casrec_csv.deputyship.\"Order No\"",
+                "LEFT JOIN casrec_csv.deputy ON casrec_csv.deputyship.\"Deputy No\" = casrec_csv.deputy.\"Deputy No\""
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_evening_phonenumbers exc_table ON exc_table.caserecnumber = casrec_csv.order.\"Case\"",
+            "where_clauses": []
+        },
+        "sirius": {
+            "from_table": "order_deputy",
+            "transform": {
+                "orderdate": "to_char({col}, 'YYYY-MM-DD')",
+                "updateddate": "to_char({col}, 'YYYY-MM-DD')"
+            },
+            "joins": [
+                "LEFT JOIN {target_schema}.cases ON cases.id = order_deputy.order_id",
+                "LEFT JOIN {target_schema}.persons ON persons.id = order_deputy.deputy_id",
+                "LEFT JOIN {target_schema}.phonenumbers ON phonenumbers.person_id = persons.id"
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_evening_phonenumbers exc_table ON exc_table.caserecnumber = persons.caserecnumber",
+            "where_clauses": [
+                "persons.type = 'actor_deputy'",
+                "persons.clientsource = 'CASRECMIGRATION'",
+                "phonenumbers.type = 'Home'"
+            ]
+        }
+    },
     "deputy_death_notifications": {
         "exclude": [
             "person_id"


### PR DESCRIPTION
## Purpose

Validation for deputy phone numbers. Protects the following mappings:

casrec_csv.deputy."Contact Telephone" => sirius.phonenumbers (type = work)
casrec_csv.deputy."Contact Tele2" => sirius.phonenumbers (type = Home)
casrec_csv.deputy."Mobile" => sirius.persons.mobilenumber

NOTE: contact_tele3 and Mobile2 don't seem to be migrating

## Approach

Usual data validation process

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
