### PR TITLE
IN-860 duplicate warnings being migrated

### DIFF
--- a/migration_steps/transform_casrec/transform/app/transform_data/transform.py
+++ b/migration_steps/transform_casrec/transform/app/transform_data/transform.py
@@ -49,7 +49,7 @@ def perform_transformations(
 
     if conditions:
         log.debug("Applying conditions to source data")
-        final_df = source_conditions(df=final_df, conditions=conditions)
+        final_df = source_conditions(df=final_df, conditions=dict(conditions))
         if len(final_df) == 0:
             log.debug(f"No data left after applying source conditions")
             raise EmptyDataFrame


### PR DESCRIPTION
Ah the old python 'not a copy' problem, you'd think I'd have learnt by now.

So once a condition has been applied I was removing that entry from the conditions dict, but because python is python, I was actually removing it from the original `table_definitions` dictionary, meaning in the second pass of the chunking the `source_conditions` key was empty.

Now, instead of using the original conditions dict, I am giving it a new dict, so when I pop stuff it only affects the new one, not the original `table_definitions` dictionary.