### PR TITLE
IN-859 & IN-874 warning, order & crec functional tests fail

### DIFF
--- a/migration_steps/shared/tables.json
+++ b/migration_steps/shared/tables.json
@@ -189,7 +189,7 @@
 				"parent_column": "id"
 			}],
 		"sequences": [{
-			"name": "notes_id_seq",
+			"name": "supervision_notes_id_seq",
 			"column": "id",
 			"type": "pk"
 		}],
@@ -221,7 +221,11 @@
 		"pk": "id",
 		"fks": [],
 		"table_type": "data",
-		"sequences": [],
+		"sequences": [{
+			"name": "warnings_id_seq",
+			"column": "id",
+			"type": "pk"
+		}],
 		"order_by": ["id"]
 	},
 	"person_warning": {

--- a/migration_steps/validation/api_tests/functional_tests/app.py
+++ b/migration_steps/validation/api_tests/functional_tests/app.py
@@ -352,14 +352,14 @@ def get_delete_data(entity):
 
 def main():
     entities = [
-        # "orders",
+        "orders",
         "bonds",
         "warnings",
         "deputies",
         "clients",
         "death",
         "supervision",
-        # "crec",
+        "crec",
     ]
 
     api_tests = ApiTests()

--- a/migration_steps/validation/api_tests/functional_tests/app.py
+++ b/migration_steps/validation/api_tests/functional_tests/app.py
@@ -14,22 +14,22 @@ from api_test import ApiTests
 
 def get_post_data(entity):
     post_data = {
-        # "warnings": [
-        #     {
-        #         "title": "Create New Warnings",
-        #         "data": {
-        #             "warningText": "<p>Blah<\/p>",
-        #             "warningType": {
-        #                 "handle": "REM - Violence Warnings",
-        #                 "label": "REM - Violence Warnings",
-        #             },
-        #         },
-        #         "url": "clients/{id}/warnings",
-        #         "expected_status": 201,
-        #         "source": "clients",
-        #         "case_references": ["10194709"],
-        #     },
-        # ],
+        "warnings": [
+            {
+                "title": "Create New Warnings",
+                "data": {
+                    "warningText": "<p>Blah<\/p>",
+                    "warningType": {
+                        "handle": "REM - Violence Warnings",
+                        "label": "REM - Violence Warnings",
+                    },
+                },
+                "url": "clients/{id}/warnings",
+                "expected_status": 201,
+                "source": "clients",
+                "case_references": ["10194709"],
+            },
+        ],
         # "death": [
         #     {
         #         "title": "Create New Death",


### PR DESCRIPTION
Turns out when you add a warning, crec or order it automatically adds a note to the supervision_notes table, so we need to reset the table sequences and the supervision_note table sequence.

Not sure what would happen if you turn the notes entity off, but as that work is now finalised that's unlikely to happen so we'll deal with that if we have to.
