### PR TITLE
IN-787 Crec DB validation

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -336,6 +336,30 @@
             ]
         }
     },
+    "crec_persons": {
+        "exclude": [
+            "supervisioncaseowner_id"
+        ],
+        "casenumber_source": "client_persons.caserecnumber",
+        "orderby": {},
+        "casrec": {
+            "from_table": "crec",
+            "transform": {},
+            "joins": [],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_crec_persons exc_table ON exc_table.caserecnumber = pat.\"Case\"",
+            "where_clauses": []
+        },
+        "sirius": {
+            "from_table": "persons",
+            "transform": {},
+            "joins": [],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_crec_persons exc_table ON exc_table.caserecnumber = persons.caserecnumber",
+            "where_clauses": [
+                "persons.type = 'actor_client'",
+                "persons.clientsource = 'CASRECMIGRATION'"
+            ]
+        }
+    },
     "deputy_daytime_phonenumbers": {
         "exclude": [
             "person_id"

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -661,7 +661,7 @@ def pre_validation():
             log.debug(f"Static validation file found! {fixed_sql_path}")
             fixedfile = open(fixed_sql_path, "r")
             for line in fixedfile:
-                sql_add(line)
+                sql_add(line.replace("{target_schema}", str(target_schema)))
             output_statement_to_file()
         else:
             log.debug("Exception Table")

--- a/migration_steps/validation/validate_db/app/fixed_sql/crec_persons.sql
+++ b/migration_steps/validation/validate_db/app/fixed_sql/crec_persons.sql
@@ -28,7 +28,7 @@ INSERT INTO casrec_csv.exceptions_crec_persons(
         SELECT DISTINCT
             persons.caserecnumber AS caserecnumber,
             persons.risk_score AS risk_score
-        FROM public.persons
+        FROM {target_schema}.persons
         WHERE persons.type = 'actor_client'
         AND persons.clientsource = 'CASRECMIGRATION'
         ORDER BY caserecnumber ASC

--- a/migration_steps/validation/validate_db/app/fixed_sql/crec_persons.sql
+++ b/migration_steps/validation/validate_db/app/fixed_sql/crec_persons.sql
@@ -1,0 +1,36 @@
+-- crec_persons
+DROP TABLE IF EXISTS casrec_csv.exceptions_crec_persons;
+
+CREATE TABLE casrec_csv.exceptions_crec_persons(
+    caserecnumber text default NULL,
+    risk_score text default NULL
+);
+
+INSERT INTO casrec_csv.exceptions_crec_persons(
+    SELECT * FROM(
+         SELECT
+             caserecnumber,
+             risk_score
+         FROM (
+            SELECT DISTINCT on (pat."Case")
+                casrec_csv.pat."Case" AS caserecnumber,
+                casrec_csv.crec_lookup(casrec_csv.crec."Score") AS risk_score,
+                to_timestamp(CONCAT(crec."Create", ' ', crec."at"), 'YYYY-MM-DD HH24:MI:SS.US') AS sortdate
+            FROM casrec_csv.crec
+            LEFT JOIN casrec_csv.pat
+                ON pat."Case" = crec."Case"
+            ORDER BY caserecnumber ASC, sortdate DESC
+            ) AS casrec
+         ORDER BY caserecnumber ASC
+     ) as csv_data
+    EXCEPT
+    SELECT * FROM(
+        SELECT DISTINCT
+            persons.caserecnumber AS caserecnumber,
+            persons.risk_score AS risk_score
+        FROM public.persons
+        WHERE persons.type = 'actor_client'
+        AND persons.clientsource = 'CASRECMIGRATION'
+        ORDER BY caserecnumber ASC
+     ) as sirius_data
+);


### PR DESCRIPTION
## Purpose
DB Validation for Crec

## Approach

Same process as with other validation - EXCEPT the SQL necessary to pull only the latest status for each client proved too complex to be generated dynamically so the necessary sql is saved to a static file.

The validation app.py now checks a directory to see if a pre-saved static SQL file is present for the entity and uses it, if present.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
