### PR TITLE
Create FinancePerson entities on localdev

### DIFF
--- a/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
+++ b/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
@@ -1086,8 +1086,24 @@ def insert_client_address_data_into_sirius(db_config, sirius_db_engine):
     sirius_db_engine.execute(insert_statement)
 
 
+def insert_finance_person_data_into_sirius(db_config, sirius_db_engine):
+    id = get_max_value(table="finance_person", column="id", db_config=db_config)
+
+    insert_statement = f"""
+        INSERT INTO finance_person (id, person_id, finance_billing_reference, payment_method)
+        SELECT
+            row_number() over () + {id} as id,
+            id as person_id,
+            row_number() over () + 990000 as finance_billing_reference,
+            'DEMANDED'
+        from persons where clientsource = 'SKELETON';
+    """
+    sirius_db_engine.execute(insert_statement)
+
+
 def insert_skeleton_data(db_config):
     sirius_db_engine = create_engine(db_config["sirius_db_connection_string"])
 
     insert_client_data_into_sirius(db_config, sirius_db_engine)
+    insert_finance_person_data_into_sirius(db_config, sirius_db_engine)
     # insert_client_address_data_into_sirius(db_config, sirius_db_engine)


### PR DESCRIPTION
## Purpose

FinancePerson entities do not need migrating because a large number have already been imported in Sirius live (245k), and the rest will be imported by the Finance team prior to data migration.

Ensure that each client on localdev has a FinancePerson entity with a unique finance_billing_reference (aka SOP number)

## Approach

Insert into finance_person table as part of setting up skeleton data on localdev

## Learning

-

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
