### PR TITLE
dont create cloud9 for preqa

### DIFF
--- a/terraform/cloud9.tf
+++ b/terraform/cloud9.tf
@@ -8,11 +8,11 @@ data "aws_subnet_ids" "public" {
 }
 
 locals {
-  cloud9_id = local.account.name == "qa" ? "1b01031b9fef4ac0ad89b6858fa4fd70" : aws_cloud9_environment_ec2.shared[0].id
+  cloud9_id = local.account.name == "preproduction" ? aws_cloud9_environment_ec2.shared[0].id : "1b01031b9fef4ac0ad89b6858fa4fd70"
 }
 
 resource "aws_cloud9_environment_ec2" "shared" {
-  count                       = local.account.name == "qa" ? 0 : 1
+  count                       = local.account.name == "preproduction" ? 1 : 0
   instance_type               = "t2.micro"
   name                        = "casrec-mig-cloud9-env"
   automatic_stop_time_minutes = 20


### PR DESCRIPTION
## Purpose

Don't create cloud9 env for preqa

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
