### PR TITLE
Use column alias instead of original column name

### DIFF
--- a/migration_steps/transform_casrec/transform/app/utilities/convert_json_to_mappings.py
+++ b/migration_steps/transform_casrec/transform/app/utilities/convert_json_to_mappings.py
@@ -31,10 +31,10 @@ class MappingDefinitions:
         transformations = {}
         for k, v in requires_transformation.items():
             tr = v["requires_transformation"]
-            d = {"original_columns": v["casrec_column_name"], "aggregate_col": k}
+            d = {"original_columns": v["alias"], "aggregate_col": k}
             if v["requires_transformation"] == "conditional_lookup":
                 d["lookup_table"] = v["lookup_table"]
-                d["original_columns"] = v["casrec_column_name"]
+                d["original_columns"] = v["alias"]
                 d["additional_columns"] = v["additional_columns"]
             if tr in transformations:
                 transformations[tr].append(d)


### PR DESCRIPTION
## Purpose

Transformations should reference the column alias instead of the original column name. In most cases they are the same, except when the transformation is on a copied column e.g. "SomeCol 1", "SomeCol 2" etc

## Approach


## Learning


## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
