### PR TITLE
Fix problems with death in team 2

### DIFF
--- a/migration_steps/load_to_sirius/move_data/insert_data.py
+++ b/migration_steps/load_to_sirius/move_data/insert_data.py
@@ -93,6 +93,9 @@ def insert_data_into_target(
         data_to_insert = pd.read_sql_query(
             sql=query, con=db_config["source_db_connection_string"]
         )
+        if len(data_to_insert) == 0:
+            log.info(f"No data to insert into {table_name}")
+            break
 
         insert_statement = create_insert_statement(
             schema=db_config["target_schema"],

--- a/migration_steps/transform_casrec/transform/app/utilities/db_insert.py
+++ b/migration_steps/transform_casrec/transform/app/utilities/db_insert.py
@@ -61,7 +61,11 @@ class InsertData:
             columns_from_df = []
 
         columns_from_mapping = mapping_details.keys()
-        temp_columns = list(set(columns_from_df) - set(columns_from_mapping))
+        temp_columns = list(
+            set(columns_from_df) - set(columns_from_mapping)
+            | set(self.standard_columns)
+        )
+
         for col in temp_columns:
             if col in self.standard_columns:
                 columns.append(f"{col} {self.standard_columns[col]}")

--- a/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
+++ b/migration_steps/validation/post_migration_tests/app/checks/continuous_ids.py
@@ -78,6 +78,8 @@ def check_continuous(table_list, db_config):
         )
         if last_original_record + 1 == first_migrated_record:
             report["pass"].append(table)
+        elif last_original_record == 0 and first_migrated_record == 0:
+            pass
         else:
             report["fail"].append(table)
 


### PR DESCRIPTION
3 parts to the problem:

1. _transform_ was not adding the `casrec_details` column to an empty table, which is needed later
2. _load_to_sirius_ insert crashed when it found an empty table (because of the refactoring I did a couple of weeks ago)
3. _post_migration_tests_ claimed `death_notifictations` had failed when in reality nothing had changed
