### PR TITLE
Lay team filtering disabled if AWS param '0'|"all"|"All"|"ALL"

### DIFF
--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -23,13 +23,13 @@ def get_enabled_entities_from_param_store(env):
 
 
 def get_lay_team_from_param_store(env):
+    lay_team = ""
     if env in ["preproduction", "qa", "preqa", "production"]:
         session = boto3.session.Session()
         ssm = session.client("ssm", region_name="eu-west-1")
         parameter = ssm.get_parameter(Name=f"{env}-lay-team")
-        lay_team = parameter["Parameter"]["Value"]
-    else:
-        lay_team = ""
+        if parameter["Parameter"]["Value"] not in ["0", "all", "All", "ALL"]:
+            lay_team = parameter["Parameter"]["Value"]
 
     return lay_team
 
@@ -113,7 +113,6 @@ class BaseConfig:
     QA_FEATURE_FLAGS = {}
 
     def enabled_feature_flags(self, env):
-
         if env in ["qa", "production"]:
             return [k for k, v in self.QA_FEATURE_FLAGS.items() if v is True]
         else:

--- a/terraform/parameter_store.tf
+++ b/terraform/parameter_store.tf
@@ -13,7 +13,7 @@ resource "aws_ssm_parameter" "allowed_entities" {
 resource "aws_ssm_parameter" "lay_team" {
   name  = "${local.account.name}-lay-team"
   type  = "String"
-  value = ""
+  value = "0"
 
   tags = local.default_tags
 


### PR DESCRIPTION
Internally translates to empty string (AWS Param store doesn't like empty values)

## Purpose

Translates AWS value of "0"|"all"|"All"|"ALL" to an empty string, internally

Filtering then works as normal (is disabled)

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
