### PR TITLE
IN-992 Fix transformations and validations for warnings

### DIFF
--- a/migration_steps/load_casrec/app/app.py
+++ b/migration_steps/load_casrec/app/app.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from datetime import datetime
 from pathlib import Path
 
 current_path = Path(os.path.dirname(os.path.realpath(__file__)))
@@ -480,7 +481,10 @@ def main(entities, delay, verbose, skip_load):
             if file.split(".")[1] == "csv":
                 df = pd.read_csv(io.BytesIO(obj["Body"].read()))
             elif file.split(".")[1] == "xlsx":
-                df = pd.read_excel(io.BytesIO(obj["Body"].read()), engine="openpyxl")
+                xlsx_converters = {
+                    "Made Date": convert_datetime_to_date
+                }
+                df = pd.read_excel(io.BytesIO(obj["Body"].read()), engine="openpyxl", converters=xlsx_converters)
             else:
                 log.info("Unknown file format")
                 exit(1)
@@ -556,6 +560,12 @@ def main(entities, delay, verbose, skip_load):
                 )
 
         log.info(f"Processor {processor_id} has finished processing")
+
+
+def convert_datetime_to_date(val):
+    if isinstance(val, datetime):
+        return val.strftime("%Y-%m-%d")
+    return val
 
 
 if __name__ == "__main__":

--- a/migration_steps/shared/custom_errors.py
+++ b/migration_steps/shared/custom_errors.py
@@ -4,8 +4,9 @@ log = logging.getLogger("root")
 
 
 class EmptyDataFrame(Exception):
-    def __init__(self, message="No data in dataframe"):
-        self.message = message
+    def __init__(self, empty_data_frame_type="chunk", message="No data in dataframe"):
+        self.empty_data_frame_type = empty_data_frame_type
+        self.message = f"{message} of type {empty_data_frame_type}"
         super().__init__(self.message)
 
 

--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -611,16 +611,13 @@
         },
         "casrec": {
             "from_table": "deputyship",
-            "transform": {
-                "dateadded": "to_char({col}, 'YYYY-MM-DD')"
-            },
+            "transform": {},
             "joins": [
                 "LEFT JOIN casrec_csv.order ON casrec_csv.order.\"Order No\" = casrec_csv.deputyship.\"Order No\"",
                 "LEFT JOIN casrec_csv.deputy ON casrec_csv.deputyship.\"Deputy No\" = casrec_csv.deputy.\"Deputy No\""
             ],
             "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_violent_warnings exc_table ON exc_table.caserecnumber = casrec_csv.order.\"Case\"",
             "where_clauses": [
-                "casrec_csv.warning_violent_lookup(casrec_csv.deputy.\"VWM\") = 'Marker'",
                 "casrec_csv.warning_violent_lookup(casrec_csv.deputy.\"VWM\") = 'Marker'"
             ]
         },
@@ -639,7 +636,7 @@
             "where_clauses": [
                 "persons.type = 'actor_deputy'",
                 "persons.clientsource = 'CASRECMIGRATION'",
-                "warnings.warningtype = 'REM - Special Interest Markers'",
+                "warnings.warningtype = 'REM - Violence Warnings'",
                 "warnings.warningtext = 'Casrec Migration - Violent Warning'"
             ]
         }

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_nodebtchase_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_nodebtchase_warnings.py
@@ -1,5 +1,4 @@
 from utilities.basic_data_table import get_basic_data_table
-import numpy as np
 
 import os
 import logging
@@ -13,8 +12,8 @@ log = logging.getLogger("root")
 def insert_client_nodebtchase_warnings(db_config, target_db, mapping_file):
 
     chunk_size = db_config["chunk_size"]
-    offset = 0
-    chunk_no = 1
+    offset = -chunk_size
+    chunk_no = 0
 
     mapping_file_name = f"{mapping_file}_mapping"
     table_definition = get_table_def(mapping_name=mapping_file)
@@ -23,8 +22,12 @@ def insert_client_nodebtchase_warnings(db_config, target_db, mapping_file):
         stage_name="sirius_details",
         only_complete_fields=False,
     )
+
     while True:
         try:
+            offset += chunk_size
+            chunk_no += 1
+
             warnings_df = get_basic_data_table(
                 db_config=db_config,
                 mapping_file_name=mapping_file_name,
@@ -40,13 +43,12 @@ def insert_client_nodebtchase_warnings(db_config, target_db, mapping_file):
                 chunk_no=chunk_no,
             )
 
-            offset += chunk_size
-            chunk_no += 1
-        except EmptyDataFrame:
+        except EmptyDataFrame as empty_data_frame:
+            if empty_data_frame.empty_data_frame_type == 'chunk':
+                target_db.create_empty_table(sirius_details=sirius_details)
+                break
+            continue
 
-            target_db.create_empty_table(sirius_details=sirius_details)
-
-            break
         except Exception as e:
             log.error(f"Unexpected error: {e}")
             os._exit(1)

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_saarcheck_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_saarcheck_warnings.py
@@ -1,5 +1,4 @@
 from utilities.basic_data_table import get_basic_data_table
-import numpy as np
 
 import os
 import logging
@@ -13,8 +12,8 @@ log = logging.getLogger("root")
 def insert_client_saarcheck_warnings(db_config, target_db, mapping_file):
 
     chunk_size = db_config["chunk_size"]
-    offset = 0
-    chunk_no = 1
+    offset = -chunk_size
+    chunk_no = 0
 
     mapping_file_name = f"{mapping_file}_mapping"
     table_definition = get_table_def(mapping_name=mapping_file)
@@ -23,7 +22,11 @@ def insert_client_saarcheck_warnings(db_config, target_db, mapping_file):
         stage_name="sirius_details",
         only_complete_fields=False,
     )
+
     while True:
+        offset += chunk_size
+        chunk_no += 1
+
         try:
             warnings_df = get_basic_data_table(
                 db_config=db_config,
@@ -40,13 +43,12 @@ def insert_client_saarcheck_warnings(db_config, target_db, mapping_file):
                 chunk_no=chunk_no,
             )
 
-            offset += chunk_size
-            chunk_no += 1
-        except EmptyDataFrame:
+        except EmptyDataFrame as empty_data_frame:
+            if empty_data_frame.empty_data_frame_type == 'chunk':
+                target_db.create_empty_table(sirius_details=sirius_details)
+                break
+            continue
 
-            target_db.create_empty_table(sirius_details=sirius_details)
-
-            break
         except Exception as e:
             log.error(f"Unexpected error: {e}")
             os._exit(1)

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_special_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_special_warnings.py
@@ -1,5 +1,4 @@
 from utilities.basic_data_table import get_basic_data_table
-import numpy as np
 
 import os
 import logging
@@ -13,8 +12,8 @@ log = logging.getLogger("root")
 def insert_client_special_warnings(db_config, target_db, mapping_file):
 
     chunk_size = db_config["chunk_size"]
-    offset = 0
-    chunk_no = 1
+    offset = -chunk_size
+    chunk_no = 0
 
     mapping_file_name = f"{mapping_file}_mapping"
     table_definition = get_table_def(mapping_name=mapping_file)
@@ -23,7 +22,11 @@ def insert_client_special_warnings(db_config, target_db, mapping_file):
         stage_name="sirius_details",
         only_complete_fields=False,
     )
+
     while True:
+        chunk_no += 1
+        offset += chunk_size
+
         try:
             warnings_df = get_basic_data_table(
                 db_config=db_config,
@@ -40,13 +43,12 @@ def insert_client_special_warnings(db_config, target_db, mapping_file):
                 chunk_no=chunk_no,
             )
 
-            offset += chunk_size
-            chunk_no += 1
-        except EmptyDataFrame:
+        except EmptyDataFrame as empty_data_frame:
+            if empty_data_frame.empty_data_frame_type == 'chunk':
+                target_db.create_empty_table(sirius_details=sirius_details)
+                break
+            continue
 
-            target_db.create_empty_table(sirius_details=sirius_details)
-
-            break
         except Exception as e:
             log.error(f"Unexpected error: {e}")
             os._exit(1)

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_violent_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_violent_warnings.py
@@ -1,5 +1,4 @@
 from utilities.basic_data_table import get_basic_data_table
-import numpy as np
 
 import os
 import logging
@@ -13,8 +12,8 @@ log = logging.getLogger("root")
 def insert_client_violent_warnings(db_config, target_db, mapping_file):
 
     chunk_size = db_config["chunk_size"]
-    offset = 0
-    chunk_no = 1
+    offset = -chunk_size
+    chunk_no = 0
 
     mapping_file_name = f"{mapping_file}_mapping"
     table_definition = get_table_def(mapping_name=mapping_file)
@@ -23,7 +22,11 @@ def insert_client_violent_warnings(db_config, target_db, mapping_file):
         stage_name="sirius_details",
         only_complete_fields=False,
     )
+
     while True:
+        offset += chunk_size
+        chunk_no += 1
+
         try:
             warnings_df = get_basic_data_table(
                 db_config=db_config,
@@ -40,13 +43,12 @@ def insert_client_violent_warnings(db_config, target_db, mapping_file):
                 chunk_no=chunk_no,
             )
 
-            offset += chunk_size
-            chunk_no += 1
-        except EmptyDataFrame:
+        except EmptyDataFrame as empty_data_frame:
+            if empty_data_frame.empty_data_frame_type == 'chunk':
+                target_db.create_empty_table(sirius_details=sirius_details)
+                break
+            continue
 
-            target_db.create_empty_table(sirius_details=sirius_details)
-
-            break
         except Exception as e:
             log.error(f"Unexpected error: {e}")
             os._exit(1)

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_person_warning.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_person_warning.py
@@ -38,7 +38,7 @@ def insert_deputy_person_warning(db_config, target_db, mapping_file):
 
         deputy_warning_query = f"""
                 select * from {db_config["target_schema"]}.warnings
-                where casrec_mapping_file_name = 'deputy_violent_warnings_mapping';"""
+                where casrec_table_name = 'deputy';"""
         deputy_warning_df = pd.read_sql_query(
             deputy_warning_query, db_config["db_connection_string"]
         )

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_special_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_special_warnings.py
@@ -1,7 +1,6 @@
 import os
 
 from utilities.basic_data_table import get_basic_data_table
-import numpy as np
 import logging
 
 from custom_errors import EmptyDataFrame
@@ -13,8 +12,8 @@ log = logging.getLogger("root")
 def insert_deputy_special_warnings(db_config, target_db, mapping_file):
 
     chunk_size = db_config["chunk_size"]
-    offset = 0
-    chunk_no = 1
+    offset = -chunk_size
+    chunk_no = 0
 
     mapping_file_name = f"{mapping_file}_mapping"
     table_definition = get_table_def(mapping_name=mapping_file)
@@ -23,7 +22,11 @@ def insert_deputy_special_warnings(db_config, target_db, mapping_file):
         stage_name="sirius_details",
         only_complete_fields=False,
     )
+
     while True:
+        chunk_no += 1
+        offset += chunk_size
+
         try:
             warnings_df = get_basic_data_table(
                 db_config=db_config,
@@ -40,13 +43,12 @@ def insert_deputy_special_warnings(db_config, target_db, mapping_file):
                 chunk_no=chunk_no,
             )
 
-            offset += chunk_size
-            chunk_no += 1
-        except EmptyDataFrame:
+        except EmptyDataFrame as empty_data_frame:
+            if empty_data_frame.empty_data_frame_type == 'chunk':
+                target_db.create_empty_table(sirius_details=sirius_details)
+                break
+            continue
 
-            target_db.create_empty_table(sirius_details=sirius_details)
-
-            break
         except Exception as e:
             log.error(f"unexpected error {e}")
             os._exit(1)

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_violent_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_violent_warnings.py
@@ -1,7 +1,6 @@
 import os
 
 from utilities.basic_data_table import get_basic_data_table
-import numpy as np
 import logging
 
 from custom_errors import EmptyDataFrame
@@ -13,8 +12,8 @@ log = logging.getLogger("root")
 def insert_deputy_violent_warnings(db_config, target_db, mapping_file):
 
     chunk_size = db_config["chunk_size"]
-    offset = 0
-    chunk_no = 1
+    offset = -chunk_size
+    chunk_no = 0
 
     mapping_file_name = f"{mapping_file}_mapping"
     table_definition = get_table_def(mapping_name=mapping_file)
@@ -23,7 +22,11 @@ def insert_deputy_violent_warnings(db_config, target_db, mapping_file):
         stage_name="sirius_details",
         only_complete_fields=False,
     )
+
     while True:
+        offset += chunk_size
+        chunk_no += 1
+
         try:
             warnings_df = get_basic_data_table(
                 db_config=db_config,
@@ -40,13 +43,12 @@ def insert_deputy_violent_warnings(db_config, target_db, mapping_file):
                 chunk_no=chunk_no,
             )
 
-            offset += chunk_size
-            chunk_no += 1
-        except EmptyDataFrame:
+        except EmptyDataFrame as empty_data_frame:
+            if empty_data_frame.empty_data_frame_type == 'chunk':
+                target_db.create_empty_table(sirius_details=sirius_details)
+                break
+            continue
 
-            target_db.create_empty_table(sirius_details=sirius_details)
-
-            break
         except Exception as e:
             log.error(f"unexpected error {e}")
             os._exit(1)

--- a/migration_steps/transform_casrec/transform/app/transform_data/apply_conditions.py
+++ b/migration_steps/transform_casrec/transform/app/transform_data/apply_conditions.py
@@ -6,7 +6,6 @@ import datetime as dt
 import numpy as np
 
 import helpers
-from custom_errors import EmptyDataFrame
 import pandas as pd
 
 
@@ -238,7 +237,4 @@ def remove_empty_rows(df, not_null_cols, how="all"):
         config.VERBOSE, f"Dataframe size after removing empty rows: {len(final_df)}"
     )
 
-    if len(final_df) == 0:
-        raise EmptyDataFrame
-    else:
-        return final_df
+    return final_df

--- a/migration_steps/transform_casrec/transform/app/transform_data/transform.py
+++ b/migration_steps/transform_casrec/transform/app/transform_data/transform.py
@@ -52,7 +52,7 @@ def perform_transformations(
         final_df = source_conditions(df=final_df, conditions=dict(conditions))
         if len(final_df) == 0:
             log.debug(f"No data left after applying source conditions")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with conditions applied")
 
     if len(simple_mapping) > 0:
         log.debug("Applying simple mappings")
@@ -61,7 +61,7 @@ def perform_transformations(
         )
         if len(final_df) == 0:
             log.debug(f"No data left after simple_mapping")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with simple mappings applied")
 
     if len(transformations) > 0:
         log.debug("Applying transformations")
@@ -70,7 +70,7 @@ def perform_transformations(
         )
         if len(final_df) == 0:
             log.debug(f"No data left after transformations")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with simple transformations applied")
 
     if len(required_columns) > 0:
         log.debug("Applying default columns")
@@ -79,7 +79,7 @@ def perform_transformations(
         )
         if len(final_df) == 0:
             log.debug(f"No data left after default columns")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with required columns applied")
 
     if len(calculated_fields) > 0:
         log.debug("Applying calculated fields")
@@ -87,7 +87,7 @@ def perform_transformations(
 
         if len(final_df) == 0:
             log.debug(f"No data left after calculated fields")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with calculations applied")
 
     if len(lookup_tables) > 0:
         log.debug("Applying lookup tables")
@@ -95,7 +95,7 @@ def perform_transformations(
 
         if len(final_df) == 0:
             log.debug(f"No data left after lookup tables")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with lookups applied")
 
     if "id" not in source_data_df.columns.values.tolist():
         log.debug("Applying unique id")
@@ -103,12 +103,12 @@ def perform_transformations(
             db_conn_string, db_schema, table_definition, final_df
         )
         if len(final_df) == 0:
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with unique IDs applied")
 
     if sirius_details:
         log.debug("Applying datatypes")
         final_df = apply_datatypes(mapping_details=sirius_details, df=final_df)
         if len(final_df) == 0:
-            raise EmptyDataFrame
+            raise EmptyDataFrame(empty_data_frame_type="chunk with datatypes applied")
 
     return final_df


### PR DESCRIPTION
## Purpose

All warnings are migrated and validated correctly.

## Approach

Update validation query for deputy_violent_warnings to use the expected warning type i.e. 'REM - Violence Warnings'

Ensure that chunking is not interrupted by an EmptyDataFrame exception raised after applying conditions.

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
