### PR TITLE
Add Bond Discharge column to horrific nauseating antipattern

### DIFF
--- a/migration_steps/load_casrec/app/app.py
+++ b/migration_steps/load_casrec/app/app.py
@@ -499,6 +499,7 @@ def main(entities, delay, verbose, skip_load):
                     "Clause Expiry": convert_datetime_to_date,
                     "Notified": convert_datetime_to_date,
                     "Letter Sent": convert_datetime_to_date,
+                    "Bond Discharge": convert_datetime_to_date,
                 }
                 df = pd.read_excel(io.BytesIO(obj["Body"].read()), engine="openpyxl", converters=xlsx_converters)
             else:


### PR DESCRIPTION
## Purpose

Handles the 'NaT' on Bond Discharge date field which is an artefact of converting Excel files with pandas

## Approach

Added another row to the tumour of exceptions which is metastasising nicely at the heart of our code

## Learning

We're going to be replacing the excel > pandas route with a copy of csv directly into postgres soon, so we'll be able to nuke it soon enough

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
