### PR TITLE
IN-933 Enable/fix phone number validations

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -301,7 +301,9 @@
             "transform": {},
             "joins": [],
             "exception_table_join": "LEFT JOIN casrec_csv.exceptions_client_phonenumbers exc_table ON exc_table.caserecnumber = pat.\"Case\"",
-            "where_clauses": []
+            "where_clauses": [
+                "casrec_csv.pat.\"Client Phone\" != ''"
+            ]
         },
         "sirius": {
             "from_table": "phonenumbers",
@@ -481,7 +483,9 @@
                 "LEFT JOIN casrec_csv.deputy ON casrec_csv.deputyship.\"Deputy No\" = casrec_csv.deputy.\"Deputy No\""
             ],
             "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_daytime_phonenumbers exc_table ON exc_table.caserecnumber = casrec_csv.order.\"Case\"",
-            "where_clauses": []
+            "where_clauses": [
+                "casrec_csv.deputy.\"Contact Telephone\" != ''"
+            ]
         },
         "sirius": {
             "from_table": "order_deputy",
@@ -529,7 +533,9 @@
                 "LEFT JOIN casrec_csv.deputy ON casrec_csv.deputyship.\"Deputy No\" = casrec_csv.deputy.\"Deputy No\""
             ],
             "exception_table_join": "LEFT JOIN casrec_csv.exceptions_deputy_evening_phonenumbers exc_table ON exc_table.caserecnumber = casrec_csv.order.\"Case\"",
-            "where_clauses": []
+            "where_clauses": [
+                "casrec_csv.deputy.\"Contact Tele2\" != ''"
+            ]
         },
         "sirius": {
             "from_table": "order_deputy",

--- a/migration_steps/validation/api_test_data_s3_upload/app/validation/csvs/invoice.csv
+++ b/migration_steps/validation/api_test_data_s3_upload/app/validation/csvs/invoice.csv
@@ -1,3 +1,5 @@
 endpoint,entity_ref,test_purpose,full_check,["feeType"],["reference"],["raisedDate"],["amount"],["amountOutstanding"],["status"]["handle"],["sopStatus"]["label"]
 /api/v1/finance/{id}/invoices,10041221,dev_api_tests,FALSE,B3,B300052/19,16/03/2020,35,35,OPEN,Reported
+/api/v1/finance/{id}/invoices,10162667,dev_api_tests,FALSE,AD|B2,AD51849/19|B200201/19,16/03/2020|19/03/2020,100|320,100|320,OPEN,Confirmed|Reported
+/api/v1/finance/{id}/invoices,10015105,dev_api_tests,FALSE,AD|B2|B3,AD40912/19|B200022/19|B300022/19,05/03/2019|16/03/2020,100|292.02|3.06,100|292.02|3.06,OPEN,Reported
 /api/v1/finance/{id}/invoices,10050512,dev_api_tests,FALSE,S2,S200075/19,16/03/2020,320,320,OPEN,Reported

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -60,7 +60,12 @@ def get_mappings():
         "cases": ["cases"],
         "crec": ["crec_persons",],
         "supervision_level": ["supervision_level_log",],
-        "deputies": ["deputy_persons", "deputy_death_notifications",],
+        "deputies": [
+            "deputy_persons",
+            "deputy_death_notifications",
+            "deputy_daytime_phonenumbers",
+            "deputy_evening_phonenumbers",
+        ],
         "bonds": ["bonds_active", "bonds_dispensed"],
         "warnings": [
             "client_nodebtchase_warnings",

--- a/scripts/api_tests_generator/app.py
+++ b/scripts/api_tests_generator/app.py
@@ -365,7 +365,17 @@ client_death_notifications_headers = [
     '["dateNotified"]',
 ]
 
-csvs = ["deputy_death_notifications"]
+invoices_headers = [
+    '["feeType"]',
+    '["reference"]',
+    '["raisedDate"]',
+    '["amount"]',
+    '["amountOutstanding"]',
+    '["status"]["handle"]',
+    '["sopStatus"]["label"]'
+]
+
+csvs = ["invoices"]
 
 search_headers = [
     "endpoint",


### PR DESCRIPTION
## Purpose

Validate that blank phone numbers are not being migrated across.

## Approach

Enable validations for "deputy_daytime_phonenumbers" and "deputy_evening_phonenumbers".

Add a where clause to the casrec side of the validation in order to exclude blank phone numbers.

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
