### PR TITLE
In 958 - Further protect PreQA env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,27 +219,27 @@ workflows:
     jobs:
       - reset_sirius_full_restore:
           name: run and monitor jenkins restore job preqa
-          environment: PreQualityAssurance
+          environment: PreQA
           sirius_environment: casrecdmpq
           filters: {branches:{only:[master]}}
       - get_latest_image:
           name: get latest tag preqa
           image_tag: qa
-          environment: PreQualityAssurance
+          environment: PreQA
           filters: {branches:{only:[master]}}
       - infrastructure:
           name: plan infra preqa
           requires: [get latest tag preqa]
           tf_workspace: preqa
           tf_command: plan
-          environment: PreQualityAssurance
+          environment: PreQA
           filters: {branches:{only:[master]}}
       - infrastructure:
           name: build infra preqa
           requires: [plan infra preqa]
           tf_workspace: preqa
           tf_command: apply
-          environment: PreQualityAssurance
+          environment: PreQA
           filters: {branches:{only:[master]}}
       - run_step_function:
           name: run the step function preqa
@@ -247,24 +247,24 @@ workflows:
           account: "preproduction"
           wait_for: "18000"
           tf_workspace: preqa
-          environment: PreQualityAssurance
+          environment: PreQA
           filters: {branches:{only:[master]}}
       - run_api_tests:
           name: run api tests preqa
           requires: [run the step function preqa]
           tf_workspace: preqa
-          environment: PreQualityAssurance
+          environment: PreQA
           filters: {branches:{only:[master]}}
       - run_elasticsearch_reset:
           name: full reindex elasticsearch preqa
           requires: [run the step function preqa]
           tf_workspace: preqa
-          environment: PreQualityAssurance
+          environment: PreQA
           filters: {branches:{only:[master]}}
       - job_complete:
           name: job complete notification
           requires: [run api tests preqa]
-          environment: PreQualityAssurance
+          environment: PreQA
           workspace: preqa
           filters: {branches:{ignore:[master]}}
   qa:
@@ -365,11 +365,11 @@ workflows:
       - get_latest_image:
           name: get latest tag preproduction
           image_tag: master
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - reset_sirius_full_restore:
           name: run and monitor jenkins restore job
-          environment: Preproduction
+          environment: PreproductionNightly
           sirius_environment: casrecdmpp
           filters: {branches:{only:[master]}}
       - infrastructure:
@@ -377,7 +377,7 @@ workflows:
           requires: [get latest tag preproduction]
           tf_workspace: preproduction
           tf_command: apply
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - run_step_function:
           name: run the step function preproduction
@@ -388,11 +388,11 @@ workflows:
           account: "preproduction"
           wait_for: "18000"
           tf_workspace: preproduction
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - tag_image_for_environment:
           name: tag image for qa
-          environment: Preproduction
+          environment: PreproductionNightly
           environment_tag: qa
           requires: [run the step function preproduction]
           filters: {branches:{only:[master]}}
@@ -400,42 +400,42 @@ workflows:
           name: run api tests preproduction
           requires: [tag image for qa]
           tf_workspace: preproduction
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - run_elasticsearch_reset:
           name: full reindex elasticsearch preproduction
           requires: [run api tests preproduction]
           tf_workspace: preproduction
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - approve:
           name: approve qa kick off
           type: approval
           requires: [tag image for qa]
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - kick_off_environment:
           name: kick off qa
           workspace: qa
           requires: [approve qa kick off]
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - approve:
           name: approve preqa kick off
           type: approval
           requires: [tag image for qa]
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - kick_off_environment:
           name: kick off preqa
           workspace: preqa
           requires: [approve preqa kick off]
-          environment: Preproduction
+          environment: PreproductionNightly
           filters: {branches:{only:[master]}}
       - job_complete:
           name: job complete notification
           requires: [run api tests preproduction]
-          environment: Preproduction
+          environment: PreproductionNightly
           workspace: preproduction
           filters: {branches:{ignore:[master]}}
 
@@ -448,11 +448,11 @@ workflows:
       - get_latest_image:
           name: get latest tag preqa
           image_tag: qa
-          environment: PreQA
+          environment: PreQANightly
           filters: {branches:{only:[master]}}
       - reset_sirius_full_restore:
           name: run and monitor jenkins restore job
-          environment: PreQA
+          environment: PreQANightly
           sirius_environment: casrecdmpq
           filters: {branches:{only:[master]}}
       - infrastructure:
@@ -460,7 +460,7 @@ workflows:
           requires: [get latest tag preqa]
           tf_workspace: preqa
           tf_command: apply
-          environment: PreQA
+          environment: PreQANightly
           filters: {branches:{only:[master]}}
       - run_step_function:
           name: run the step function preqa
@@ -471,18 +471,18 @@ workflows:
           account: "preqa"
           wait_for: "18000"
           tf_workspace: preqa
-          environment: PreQA
+          environment: PreQANightly
           filters: {branches:{only:[master]}}
       - run_elasticsearch_reset:
           name: full reindex elasticsearch preqa
           requires: [run the step function preqa]
           tf_workspace: preqa
-          environment: PreQA
+          environment: PreQANightly
           filters: {branches:{only:[master]}}
       - job_complete:
           name: job complete notification
           requires: [run the step function preqa]
-          environment: PreQA
+          environment: PreQANightly
           workspace: preqa
           filters: {branches:{ignore:[master]}}
 
@@ -1219,6 +1219,15 @@ jobs:
           root: .
           paths:
             - VERSION
+      - when:
+          condition:
+            and:
+              - equal: [PreQANightly, << parameters.environment >>]
+          steps:
+            - run:
+                name: Run preprod previous build success test
+                command: python3 last_pre_migration_success.py --role migrations-ci
+                working_directory: ~/project/scripts/ci_scripts
       - notififications/notify_env_vars
       - notififications/notify_if_fail
 

--- a/scripts/ci_scripts/last_pre_migration_success.py
+++ b/scripts/ci_scripts/last_pre_migration_success.py
@@ -1,0 +1,70 @@
+import boto3
+import click
+import sys
+
+
+class StepFunctionSuccessChecker:
+    def __init__(self):
+        self.session = ""
+        self.sf_client = boto3.client("sts")
+        self.region = "eu-west-1"
+        self.sf_arn = ""
+        self.execution_arn = ""
+
+    def set_step_function_arn(self, step_function_name):
+        state_machines = self.sf_client.list_state_machines()
+        for machine in state_machines["stateMachines"]:
+            if machine["name"] == step_function_name:
+                print(f'Setting ARN to: {machine["stateMachineArn"]}')
+                self.sf_arn = machine["stateMachineArn"]
+                return machine["stateMachineArn"]
+        print("No state machine of given name exists")
+        sys.exit(1)
+
+    def get_latest_execution_status(self):
+        executions = self.sf_client.list_executions(stateMachineArn=self.sf_arn)
+
+        return executions["executions"][0]["status"]
+
+    def assume_aws_session(self, account, role):
+        """
+        Assume an AWS session so that we can access AWS resources as that account
+        """
+
+        client = boto3.client("sts")
+        role_to_assume = f"arn:aws:iam::{account}:role/{role}"
+        response = client.assume_role(
+            RoleArn=role_to_assume, RoleSessionName="assumed_role"
+        )
+
+        self.session = boto3.Session(
+            aws_access_key_id=response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+            aws_session_token=response["Credentials"]["SessionToken"],
+        )
+
+        self.sf_client = self.session.client("stepfunctions", region_name=self.region)
+
+
+@click.command()
+@click.option("--role", default="operator")
+def main(role):
+    account_id = "492687888235"
+    sf_name = "casrec-mig-state-machine-preproduction"
+
+    sf_success_checker = StepFunctionSuccessChecker()
+    sf_success_checker.assume_aws_session(account_id, role)
+    sf_success_checker.set_step_function_arn(sf_name)
+    status = sf_success_checker.get_latest_execution_status()
+
+    if status == "SUCCEEDED":
+        print("Last PreProd Run successful - Carrying on with PreQA run")
+    else:
+        print(
+            "Last PreProd Run unsuccessful - Failing PreQA run to minimise risk to environment"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Bit concerned about knocking out Preprod and PreQa with the nightly builds if theres some config issue or whatnot. This should make sure we don't break both ever.

## Approach

Checks there's a green build on Pre step function at least before deploying. It's fine for it to deploy if API tests or something else later breaks but we need at least the step function to have completed. 

It will still use the last tag from the last fully green build to build from.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
