### PR TITLE
IN-868 Payments batching and validation

### DIFF
--- a/scripts/finance/payments/1. get_last_ledger_and_allocation_ids.sql
+++ b/scripts/finance/payments/1. get_last_ledger_and_allocation_ids.sql
@@ -1,0 +1,8 @@
+-- record the last ledger entry and allocation IDs prior to importing payments
+-- so that imported payments can be batched together
+CREATE TABLE public.temp_payments_migration_last_ids AS
+    SELECT MAX(le.id) as last_ledger_entry_id, MAX(lea.id) as last_ledger_entry_allocation_id
+    FROM public.finance_ledger le
+    LEFT JOIN public.finance_ledger_allocation lea ON le.id = lea.ledger_entry_id;
+
+SELECT * FROM public.temp_payments_migration_last_ids;

--- a/scripts/finance/payments/2. import_payments.sql
+++ b/scripts/finance/payments/2. import_payments.sql
@@ -1,0 +1,1 @@
+-- payments imported manually via Sirius front-end

--- a/scripts/finance/payments/3. batch_payments.sql
+++ b/scripts/finance/payments/3. batch_payments.sql
@@ -1,0 +1,18 @@
+-- create a new batch number to be used for payments ledger entries and allocations
+UPDATE public.finance_counter
+SET counter = counter + 1
+WHERE key = 'DatFileBatchNumberReportBatchNumber';
+
+-- set batch number on ledger entries
+UPDATE public.finance_ledger fl
+SET batchnumber = counter
+FROM public.finance_counter fc
+WHERE fc.key = 'DatFileBatchNumberReportBatchNumber'
+AND fl.id > (SELECT last_ledger_entry_id FROM temp_payments_migration_last_ids);
+
+-- set batch number on ledger entry allocations
+UPDATE public.finance_ledger_allocation fla
+SET batchnumber = counter
+FROM public.finance_counter fc
+WHERE fc.key = 'DatFileBatchNumberReportBatchNumber'
+AND fla.id > (SELECT last_ledger_entry_allocation_id FROM temp_payments_migration_last_ids);

--- a/scripts/finance/payments/4. validations.sql
+++ b/scripts/finance/payments/4. validations.sql
@@ -1,0 +1,22 @@
+-- get number of imported ledger entries and their batch number
+SELECT batchnumber, COUNT(*) AS num_imported_ledger_entries
+FROM public.finance_ledger
+WHERE id > (SELECT last_ledger_entry_id FROM temp_payments_migration_last_ids)
+GROUP BY batchnumber;
+
+-- get number of imported ledger entry allocations and their batch number
+SELECT batchnumber, COUNT(*) AS num_imported_ledger_entry_allocations
+FROM public.finance_ledger_allocation
+WHERE id > (SELECT last_ledger_entry_allocation_id FROM temp_payments_migration_last_ids)
+GROUP BY batchnumber;
+
+-- get number of batched payments, grouped and ordered by calendar date
+SELECT
+  DATE(le.datetime) AS payment_date,
+  COUNT(le.batchnumber) AS num_batched_ledger_entries,
+  SUM(CASE WHEN lea.batchnumber IS NULL THEN 0 ELSE 1 END) AS num_batched_ledger_entry_allocations
+FROM public.finance_ledger le
+LEFT JOIN public.finance_ledger_allocation lea ON le.id = lea.ledger_entry_id
+WHERE le.batchnumber = (SELECT counter FROM public.finance_counter WHERE key = 'DatFileBatchNumberReportBatchNumber')
+GROUP BY payment_date
+ORDER BY payment_date ASC;

--- a/scripts/finance/payments/5. cleanup.sql
+++ b/scripts/finance/payments/5. cleanup.sql
@@ -1,0 +1,2 @@
+-- remove temp table
+DROP TABLE public.temp_payments_migration_last_ids;


### PR DESCRIPTION
## Purpose

Payments differ from all other entities in that they will be imported manually via Sirius front-end after data migration has ran.

We need a way of batching all imported payments together, and report on the number of migrated/batched ledger entries and allocations per calendar day.

## Approach

Not sure of the best place to put these scripts because they will be executed manually after data migration:

1. Store the last ledger entry and allocation IDs in a temporary table prior to importing payments.

2. Import payments (manual process)

3. Create a new batch number in Sirius DB and set it on all newly created ledger entries and allocations.

4. Report on number of newly created ledger entries and allocations, grouped by batch number, to ensure that everything has been batched and the correct number of imported payments is returned. Also report on number of batched payments grouped by calendar date, to ensure the correct number of payments have been imported for each day.

5. Clean up script - currently just to drop the temp table.

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
