### PR TITLE
Lockpython

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,7 +560,7 @@ orbs:
     executors:
       python:
         docker:
-          - image: circleci/python:3
+          - image: cimg/python:3.9.5
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN


### PR DESCRIPTION
Wasn't locked to specific version and python 3.10 was causing issue with our build. 