### PR TITLE
IN-957 Update crec validation

### DIFF
--- a/migration_steps/validation/validate_db/app/sql/fixed_sql/crec_persons.sql
+++ b/migration_steps/validation/validate_db/app/sql/fixed_sql/crec_persons.sql
@@ -19,7 +19,7 @@ INSERT INTO casrec_csv.exceptions_crec_persons(
         SELECT
         casrec_csv.pat."Case" AS caserecnumber,
         casrec_csv.crec_lookup(casrec_csv.crec."Score") AS risk_score,
-        to_timestamp(CONCAT(CASE WHEN crec."Modify" = '' THEN '1900-01-01' WHEN crec."Modify" = 'NaT' THEN '1900-01-01' ELSE LEFT(crec."Modify", 10) END, ' ', crec."at.1"), 'YYYY-MM-DD HH24:MI:SS.US') AS sortdate
+        to_timestamp(CONCAT(CASE WHEN crec."Modify" = '' THEN '1900-01-01' WHEN crec."Modify" = 'NaT' THEN '1900-01-01' ELSE LEFT(crec."Modify", 10) END, ' ', crec."at"), 'YYYY-MM-DD HH24:MI:SS.US') AS sortdate
         FROM casrec_csv.crec
         LEFT JOIN casrec_csv.pat
         ON pat."Case" = crec."Case"


### PR DESCRIPTION
## Purpose

Crec mapping now uses "at" column instead of "at.1"

## Approach

Update DB validation accordingly

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
