### PR TITLE
Add tasks DB validation

### DIFF
--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -94,7 +94,7 @@ class BaseConfig:
         "ledger_allocation",
         "remarks",
         "reporting",
-        "tasks",
+        # "tasks",
         "visits",
         "warnings",
         "death",

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -788,6 +788,14 @@ def main(team, staging):
     log.info("RUN POST VALIDATION")
     post_validation()
 
+    if get_exception_count() > 0:
+        # TODO: remove conditional once all validation errors are fixed in preproduction
+        if environment in ["local", "development"]:
+            exit(1)
+        log.info("Exceptions WERE found: override / continue anyway\n")
+    else:
+        log.info("No exceptions found: continue...\n")
+
 
 if __name__ == "__main__":
     t = time.process_time()


### PR DESCRIPTION
## Purpose

Tasks DB automated validation.

This entity is commented out in config.py - the validation will run on dev/local when 'tasks' is uncommented in config.py and on the other environments when 'tasks' is added to the 'allowed-entities' param in AWS parameter store (per environment)

## The following SQL is generated by this validation 

```
INSERT INTO casrec_csv.exceptions_tasks(
    SELECT * FROM(
        SELECT DISTINCT
            casrec_csv.pat."Case" AS caserecnumber,
            1 AS assignee_id,
            NULLIF(TRIM('Not started'), '') AS status,
            NULLIF(TRIM(casrec_csv.sup_activity."Next Due"), '') AS duedate,
            NULLIF(TRIM(casrec_csv.sup_activity."Start Date"), '') AS activedate,
            NULLIF(TRIM(casrec_csv.task_type_lookup(casrec_csv.sup_activity."Sup Desc")), '') AS name,
            NULLIF(TRIM(casrec_csv.sup_activity."Comment"), '') AS description,
            NULLIF(TRIM(casrec_csv.sup_activity."Date Create"), '') AS createdtime
        FROM casrec_csv.SUP_ACTIVITY
        LEFT JOIN casrec_csv.pat ON casrec_csv.pat."Case" = casrec_csv.sup_activity."Case"
        WHERE True
        AND casrec_csv.sup_activity."Status" IN ('INACTIVE','ACTIVE')
        ORDER BY caserecnumber ASC
    ) as csv_data
    EXCEPT
    SELECT * FROM(
        SELECT DISTINCT
            persons.caserecnumber AS caserecnumber,
            tasks.assignee_id AS assignee_id,
            NULLIF(TRIM(tasks.status), '') AS status,
            to_char(tasks.duedate, 'YYYY-MM-DD') AS duedate,
            to_char(tasks.activedate, 'YYYY-MM-DD') AS activedate,
            NULLIF(TRIM(tasks.name), '') AS name,
            NULLIF(TRIM(tasks.description), '') AS description,
            to_char(tasks.createdtime, 'YYYY-MM-DD') AS createdtime
        FROM public.tasks
        LEFT JOIN public.person_task pt ON pt.task_id = tasks.id
        LEFT JOIN public.persons ON persons.id = pt.person_id
        WHERE True
        AND tasks.status = 'Not started'
        AND persons.type = 'actor_client'
        ORDER BY caserecnumber ASC
    ) as sirius_data
);

```

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
