### PR TITLE
IN-887 API tests for Deputy Fee Payer

### DIFF
--- a/migration_steps/validation/api_test_data_s3_upload/app/validation/csvs/deputy_fee_payer.csv
+++ b/migration_steps/validation/api_test_data_s3_upload/app/validation/csvs/deputy_fee_payer.csv
@@ -1,0 +1,3 @@
+endpoint,entity_ref,test_purpose,full_check,["feePayer"]
+/api/v1/orders/{id1}/deputies/{id2},10007163,dev_api_tests,FALSE,False|True
+/api/v1/orders/{id1}/deputies/{id2},10317585,dev_api_tests,FALSE,False|True

--- a/migration_steps/validation/api_tests/shared/api_test.py
+++ b/migration_steps/validation/api_tests/shared/api_test.py
@@ -69,6 +69,7 @@ class ApiTests:
                 "deputies",
                 "deputy_orders",
                 "deputy_clients_count",
+                "deputy_fee_payer",
                 "supervision_level",
                 "bonds",
                 "client_death_notifications",
@@ -85,6 +86,7 @@ class ApiTests:
                 "deputies",
                 "deputy_orders",
                 "deputy_clients_count",
+                "deputy_fee_payer",
                 "supervision_level",
                 "bonds",
                 "client_death_notifications",
@@ -269,7 +271,7 @@ class ApiTests:
                     deputies = self.get_deputy_entity_ids(entity_id)
                     for deputy in deputies:
                         ids.append(deputy)
-                elif self.csv in ["deputy_orders"]:
+                elif self.csv in ["deputy_orders", "deputy_fee_payer"]:
                     deputy_orders = self.get_deputy_order_entity_ids(entity_id)
                     for deputy_order in deputy_orders:
                         ids.append(deputy_order)
@@ -315,6 +317,7 @@ class ApiTests:
             "deputy_orders",
             "deputy_clients_count",
             "deputy_death_notifications",
+            "deputy_fee_payer"
         ]:
             ids = self.get_entity_ids_from_order_source(order_id_sql, caserecnumber)
         log.debug(f"returning ids: {ids}")
@@ -562,7 +565,7 @@ class ApiTests:
 
     def get_endpoint_final(self, entity_id, endpoint):
         log.debug(f"get_endpoint_final: entity_id {entity_id} endpoint {endpoint}")
-        if self.csv == "deputy_orders":
+        if self.csv in ["deputy_orders", "deputy_fee_payer"]:
             endpoint_final = (
                 str(endpoint)
                 .replace("{id1}", str(entity_id["order_id"]))

--- a/scripts/api_tests_generator/app.py
+++ b/scripts/api_tests_generator/app.py
@@ -94,6 +94,7 @@ def get_entity_ids(csv_type, caserecnumber, engine, conn):
         "deputy_clients",
         "deputy_orders",
         "deputy_death_notifications",
+        "deputy_fee_payer"
     ]:
         entity_ids = engine.execute(order_id_sql)
         if entity_ids.rowcount < 1:
@@ -109,7 +110,7 @@ def get_entity_ids(csv_type, caserecnumber, engine, conn):
                     deputies = get_deputy_entity_ids(entity_id, conn)
                     for deputy in deputies:
                         ids.append(deputy)
-                elif csv_type in ["deputy_orders"]:
+                elif csv_type in ["deputy_orders", "deputy_fee_payer"]:
                     deputy_orders = get_deputy_order_entity_ids(entity_id, conn)
                     for deputy_order in deputy_orders:
                         ids.append(deputy_order)
@@ -221,7 +222,7 @@ def get_deputy_person_entity_ids(entity_id, conn):
 
 
 def get_endpoint_final(entity_id, endpoint, csv):
-    if csv == "deputy_orders":
+    if csv in ["deputy_orders", "deputy_fee_payer"]:
         endpoint_final = (
             str(endpoint)
             .replace("{id1}", str(entity_id["order_id"]))
@@ -392,7 +393,11 @@ orders_updated_cases = [
     '["orderExpiryDate"]',
 ]
 
-csvs = []
+deputy_fee_payer_headers = [
+    '["feePayer"]'
+]
+
+csvs = ["deputy_fee_payer"]
 
 search_headers = [
     "endpoint",

--- a/scripts/api_tests_generator/deputy_fee_payer.csv
+++ b/scripts/api_tests_generator/deputy_fee_payer.csv
@@ -1,0 +1,3 @@
+endpoint,entity_ref,test_purpose,full_check
+/api/v1/orders/{id1}/deputies/{id2},10007163,dev_api_tests,FALSE
+/api/v1/orders/{id1}/deputies/{id2},10317585,dev_api_tests,FALSE


### PR DESCRIPTION
## Purpose

Add API tests for Deputy Fee Payer

## Approach

Check that /api/v1/orders/{id1}/deputies/{id2} endpoint returns correct Deputy Fee Payer flag

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
