### PR TITLE
IN-866 Reset death_notifications ID sequence

### DIFF
--- a/migration_steps/shared/tables.json
+++ b/migration_steps/shared/tables.json
@@ -210,7 +210,11 @@
 				"parent_column": "id"
 			}],
 		"table_type": "data",
-		"sequences": [],
+		"sequences": [{
+			"name": "death_notifications_id_seq",
+			"column": "id",
+			"type": "pk"
+		}],
 		"order_by": ["id"]
 	},
 	"warnings": {


### PR DESCRIPTION
## Purpose

Prevent duplicate primary key constraint errors when recording death notifications post-migration.

## Approach

Reset the ID sequence

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
