### PR TITLE
IN-970 Fix deputy_feepayer validation errors

### DIFF
--- a/migration_steps/validation/validate_db/app/sql/fixed_sql/deputy_feepayer_id.sql
+++ b/migration_steps/validation/validate_db/app/sql/fixed_sql/deputy_feepayer_id.sql
@@ -14,11 +14,16 @@ INSERT INTO casrec_csv.exceptions_deputy_feepayer_id(
         FROM casrec_csv.pat
         LEFT JOIN casrec_csv.deputyship
             ON deputyship."Case" = pat."Case"
-            AND deputyship."Fee Payer" = 'Y'
         LEFT JOIN casrec_csv.deputy
             ON deputy."Deputy No" = deputyship."Deputy No"
-            AND deputy."Stat" = '1'
         WHERE True
+            AND deputy."Stat" = '1'
+            AND deputyship."Fee Payer" = 'Y'
+            AND pat."Case" NOT IN (
+                    '11065340',
+                    '13097967',
+                    '11854030'
+                )
         ORDER BY pat."Case"
      ) as csv_data
     EXCEPT
@@ -30,6 +35,11 @@ INSERT INTO casrec_csv.exceptions_deputy_feepayer_id(
         WHERE True
             AND persons.type = 'actor_client'
             AND persons.clientsource = 'CASRECMIGRATION'
+            AND persons.caserecnumber NOT IN (
+                    '11065340',
+                    '13097967',
+                    '11854030'
+                )
         ORDER BY caserecnumber ASC
      ) as sirius_data
 );


### PR DESCRIPTION
## Purpose

Fix deputy_feepayer validation errors

## Approach

Tweaked the validation query to remove duplicate pat."Case" numbers.

Added exceptions for cases where the deputies are not linked correctly to the order(s). These cases are also in `manual_checks` exceptions for `deputy_persons` validation - to be fixed by IN-966

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
