### PR TITLE
Ensure default value is used in cases where lookup is null

### DIFF
--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -303,7 +303,11 @@ def get_casrec_col_source(col_key: str, col_definition):
         sql = f'{source_schema}.{table}."{col_name}"'
         if "" != col_definition["lookup_table"]:
             db_lookup_func = col_definition["lookup_table"]
-            sql = f"{source_schema}.{db_lookup_func}({sql})"
+            if "" != col_definition["default_value"]:
+                sql = f"CASE WHEN {source_schema}.{db_lookup_func}({sql}) is null " \
+                      f"THEN {get_casrec_default_value(col_key)} ELSE {source_schema}.{db_lookup_func}({sql}) END"
+            else:
+                sql = f"{source_schema}.{db_lookup_func}({sql})"
     elif "" != col_definition["default_value"]:
         sql = get_casrec_default_value(col_key)
     elif "" != col_definition["calculated"]:


### PR DESCRIPTION
## Purpose

I don't know how this wasn't picked up until tasks, but we use default value in validation in cases where lookup is null.
Mustn't affect any other entities.
Fixed.

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
