### PR TITLE
IN-965 Fix create table statement when first chunk is empty 

### DIFF
--- a/migration_steps/shared/custom_errors.py
+++ b/migration_steps/shared/custom_errors.py
@@ -4,9 +4,10 @@ log = logging.getLogger("root")
 
 
 class EmptyDataFrame(Exception):
-    def __init__(self, empty_data_frame_type="chunk", message="No data in dataframe"):
+    def __init__(self, empty_data_frame_type="chunk", message="No data in dataframe", df=None):
         self.empty_data_frame_type = empty_data_frame_type
         self.message = f"{message} of type {empty_data_frame_type}"
+        self.df = df
         super().__init__(self.message)
 
 

--- a/migration_steps/shared/db_insert.py
+++ b/migration_steps/shared/db_insert.py
@@ -259,13 +259,13 @@ class InsertData:
             log.error("Multiple dest tables")
             return ""
 
-    def create_empty_table(self, sirius_details):
+    def create_empty_table(self, sirius_details, df=None):
         table_name = self._get_dest_table(mapping_dict=sirius_details)
         if self._check_table_exists(table_name=table_name):
             pass
         else:
             create_statement = self._create_table_statement_with_datatype(
-                mapping_details=sirius_details, table_name=table_name
+                mapping_details=sirius_details, table_name=table_name, df=df
             )
 
             try:
@@ -362,7 +362,7 @@ class InsertData:
 
         if len(df) == 0:
             log.info(f"0 records to insert into '{table_name}' table")
-            raise EmptyDataFrame
+            raise EmptyDataFrame(df=df)
 
         if not table_name:
             table_name = self._get_dest_table(mapping_dict=sirius_details)

--- a/migration_steps/transform_casrec/transform/app/entities/bonds/bonds_active.py
+++ b/migration_steps/transform_casrec/transform/app/entities/bonds/bonds_active.py
@@ -63,7 +63,7 @@ def insert_bonds_active(target_db, db_config, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/bonds/bonds_dispensed.py
+++ b/migration_steps/transform_casrec/transform/app/entities/bonds/bonds_dispensed.py
@@ -63,7 +63,7 @@ def insert_bonds_dispensed(target_db, db_config, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/cases/cases.py
+++ b/migration_steps/transform_casrec/transform/app/entities/cases/cases.py
@@ -60,7 +60,7 @@ def insert_cases(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == "chunk":
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/clients/addresses.py
+++ b/migration_steps/transform_casrec/transform/app/entities/clients/addresses.py
@@ -58,7 +58,7 @@ def insert_addresses_clients(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == "chunk":
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/clients/person_caseitem.py
+++ b/migration_steps/transform_casrec/transform/app/entities/clients/person_caseitem.py
@@ -58,9 +58,9 @@ def insert_person_caseitem(db_config, target_db, mapping_file):
             sirius_details=sirius_details,
         )
 
-    except EmptyDataFrame:
+    except EmptyDataFrame as empty_data_frame:
 
-        target_db.create_empty_table(sirius_details=sirius_details)
+        target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
     except Exception as e:
         log.debug(

--- a/migration_steps/transform_casrec/transform/app/entities/clients/persons.py
+++ b/migration_steps/transform_casrec/transform/app/entities/clients/persons.py
@@ -42,7 +42,7 @@ def insert_persons_clients(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/clients/phonenumbers.py
+++ b/migration_steps/transform_casrec/transform/app/entities/clients/phonenumbers.py
@@ -58,7 +58,7 @@ def insert_phonenumbers_clients(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == "chunk":
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/crec/persons.py
+++ b/migration_steps/transform_casrec/transform/app/entities/crec/persons.py
@@ -77,7 +77,7 @@ def insert_persons_crec(db_config, target_db, mapping_file):
 
     except EmptyDataFrame as empty_data_frame:
         if empty_data_frame.empty_data_frame_type == "chunk":
-            target_db.create_empty_table(sirius_details=sirius_details)
+            target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
     except Exception as e:
         log.error(f"Unexpected error: {e}")

--- a/migration_steps/transform_casrec/transform/app/entities/death/client_death_notifications.py
+++ b/migration_steps/transform_casrec/transform/app/entities/death/client_death_notifications.py
@@ -61,7 +61,7 @@ def insert_client_death_notifications(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/death/deputy_death_notifications.py
+++ b/migration_steps/transform_casrec/transform/app/entities/death/deputy_death_notifications.py
@@ -65,7 +65,7 @@ def insert_deputy_death_notifications(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/addresses.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/addresses.py
@@ -111,7 +111,7 @@ def insert_addresses_deputies(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/order_deputy.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/order_deputy.py
@@ -112,7 +112,7 @@ def insert_order_deputies(db_config, target_db, mapping_file):
 
     except EmptyDataFrame:
 
-        target_db.create_empty_table(sirius_details=sirius_details)
+        target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
     except Exception as e:
         log.debug(

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/persons.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/persons.py
@@ -42,7 +42,7 @@ def insert_persons_deputies(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/phonenumbers_daytime.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/phonenumbers_daytime.py
@@ -68,7 +68,7 @@ def insert_phonenumbers_deputies_daytime(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/phonenumbers_evening.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/phonenumbers_evening.py
@@ -68,7 +68,7 @@ def insert_phonenumbers_deputies_evening(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/invoice/finance_invoice.py
+++ b/migration_steps/transform_casrec/transform/app/entities/invoice/finance_invoice.py
@@ -84,7 +84,7 @@ def insert_finance_invoice(target_db, db_config, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/ledger/finance_ledger.py
+++ b/migration_steps/transform_casrec/transform/app/entities/ledger/finance_ledger.py
@@ -60,7 +60,7 @@ def insert_finance_ledger_credits(target_db, db_config, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
                 break
 

--- a/migration_steps/transform_casrec/transform/app/entities/ledger_allocation/finance_allocation.py
+++ b/migration_steps/transform_casrec/transform/app/entities/ledger_allocation/finance_allocation.py
@@ -91,7 +91,7 @@ def insert_finance_allocation_credits(target_db, db_config, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
                 break
 

--- a/migration_steps/transform_casrec/transform/app/entities/remarks/client_notes.py
+++ b/migration_steps/transform_casrec/transform/app/entities/remarks/client_notes.py
@@ -62,7 +62,7 @@ def insert_client_notes(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/remarks/deputy_notes.py
+++ b/migration_steps/transform_casrec/transform/app/entities/remarks/deputy_notes.py
@@ -64,7 +64,7 @@ def insert_deputy_notes(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_lodging_details.py
+++ b/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_lodging_details.py
@@ -43,7 +43,7 @@ def insert_annual_report_lodging_details(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_logs.py
+++ b/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_logs.py
@@ -74,7 +74,7 @@ def insert_annual_report_logs(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_type_assignments.py
+++ b/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_type_assignments.py
@@ -49,9 +49,9 @@ def insert_annual_report_type_assignments(db_config, target_db, mapping_file):
     #         offset += chunk_size
     #         chunk_no += 1
     #
-    #     except EmptyDataFrame:
+    #     except EmptyDataFrame as empty_data_frame:
     #
-    #         target_db.create_empty_table(sirius_details=sirius_details)
+    #         target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
     #
     #         break
     #

--- a/migration_steps/transform_casrec/transform/app/entities/supervision_level/supervision_level_log.py
+++ b/migration_steps/transform_casrec/transform/app/entities/supervision_level/supervision_level_log.py
@@ -56,7 +56,7 @@ def insert_supervision_level_log(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/tasks/tasks.py
+++ b/migration_steps/transform_casrec/transform/app/entities/tasks/tasks.py
@@ -51,7 +51,7 @@ def insert_tasks(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == "chunk":
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/visits/visits.py
+++ b/migration_steps/transform_casrec/transform/app/entities/visits/visits.py
@@ -65,7 +65,7 @@ def insert_visits(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_nodebtchase_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_nodebtchase_warnings.py
@@ -45,7 +45,7 @@ def insert_client_nodebtchase_warnings(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_person_warning.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_person_warning.py
@@ -70,9 +70,9 @@ def insert_client_person_warning(db_config, target_db, mapping_file):
             df=client_warning_df,
             sirius_details=sirius_details,
         )
-    except EmptyDataFrame:
+    except EmptyDataFrame as empty_data_frame:
 
-        target_db.create_empty_table(sirius_details=sirius_details)
+        target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
     except Exception as e:
         print(e)

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_saarcheck_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_saarcheck_warnings.py
@@ -45,7 +45,7 @@ def insert_client_saarcheck_warnings(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_special_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_special_warnings.py
@@ -45,7 +45,7 @@ def insert_client_special_warnings(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/client_violent_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/client_violent_warnings.py
@@ -45,7 +45,7 @@ def insert_client_violent_warnings(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_person_warning.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_person_warning.py
@@ -70,9 +70,9 @@ def insert_deputy_person_warning(db_config, target_db, mapping_file):
             df=deputy_warning_df,
             sirius_details=sirius_details,
         )
-    except EmptyDataFrame:
+    except EmptyDataFrame as empty_data_frame:
 
-        target_db.create_empty_table(sirius_details=sirius_details)
+        target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
 
     except Exception as e:
         log.debug(

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_special_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_special_warnings.py
@@ -45,7 +45,7 @@ def insert_deputy_special_warnings(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_violent_warnings.py
+++ b/migration_steps/transform_casrec/transform/app/entities/warnings/deputy_violent_warnings.py
@@ -45,7 +45,7 @@ def insert_deputy_violent_warnings(db_config, target_db, mapping_file):
 
         except EmptyDataFrame as empty_data_frame:
             if empty_data_frame.empty_data_frame_type == 'chunk':
-                target_db.create_empty_table(sirius_details=sirius_details)
+                target_db.create_empty_table(sirius_details=sirius_details, df=empty_data_frame.df)
                 break
             continue
 

--- a/migration_steps/transform_casrec/transform/app/utilities/basic_data_table.py
+++ b/migration_steps/transform_casrec/transform/app/utilities/basic_data_table.py
@@ -57,7 +57,7 @@ def get_basic_data_table(
 
     if len(source_data_df) == 0:
         log.debug(f"No data returned from database")
-        raise EmptyDataFrame
+        raise EmptyDataFrame(df=source_data_df)
 
     result_df = transform.perform_transformations(
         mapping_definitions=mapping_dict,

--- a/migration_steps/transform_casrec/transform/app/utilities/custom_errors.py
+++ b/migration_steps/transform_casrec/transform/app/utilities/custom_errors.py
@@ -5,5 +5,11 @@ log = logging.getLogger("root")
 
 class EmptyDataFrame(Exception):
     def __init__(self, message="No data in dataframe"):
+        """
+        TODO: believe this may be deprecated and can be removed
+
+        df: empty dataframe which caused the exception; retained so
+            we can access its column metadata
+        """
         self.message = message
         super().__init__(self.message)


### PR DESCRIPTION
## Purpose

[IN-965](https://opgtransform.atlassian.net/browse/IN-965)

## Approach

This is the long-winded approach (versus the shelved refactor of [IN-967](https://opgtransform.atlassian.net/browse/IN-967)) to passing the dataframe into all EmptyDataFrame exceptions so that it can be used to construct a proper CREATE TABLE statement when the dataframe is empty. This should rarely/never happen, but may happen if the first migrated chunk for a table has no records in it. In this situation, the create statement may be missing columns which would otherwise be extracted from the dataframe and therefore be incorrect (see the issue for detail).

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have added relevant logging with appropriate levels to my code
* [X] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
