### PR TITLE
Prevent finance_person_id from being converted to float

### DIFF
--- a/migration_steps/load_to_sirius/move_data/utilities.py
+++ b/migration_steps/load_to_sirius/move_data/utilities.py
@@ -14,7 +14,13 @@ completed_tables = []
 
 log = logging.getLogger("root")
 
-SPECIAL_CASES = ["addresses", "persons"]
+SPECIAL_CASES = [
+    "addresses",
+    "persons",
+    "finance_invoice",
+    "finance_ledger",
+    "finance_remission_exemption"
+]
 
 
 def handle_special_cases(table_name, df):
@@ -26,6 +32,15 @@ def handle_special_cases(table_name, df):
         df["risk_score"] = df["risk_score"].astype("Int64")
         log.debug("Reformat 'feepayer_id' to nullable int")
         df["feepayer_id"] = df["feepayer_id"].astype("Int64")
+    if table_name == "finance_invoice":
+        log.debug("Reformat 'finance_person_id' to nullable int")
+        df["finance_person_id"] = df["finance_person_id"].astype("Int64")
+    if table_name == "finance_ledger":
+        log.debug("Reformat 'finance_person_id' to nullable int")
+        df["finance_person_id"] = df["finance_person_id"].astype("Int64")
+    if table_name == "finance_remission_exemption":
+        log.debug("Reformat 'finance_person_id' to nullable int")
+        df["finance_person_id"] = df["finance_person_id"].astype("Int64")
     return df
 
 

--- a/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
+++ b/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
@@ -1096,7 +1096,7 @@ def insert_finance_person_data_into_sirius(db_config, sirius_db_engine):
             id as person_id,
             row_number() over () + 990000 as finance_billing_reference,
             'DEMANDED'
-        from persons where clientsource = 'SKELETON';
+        from persons where clientsource = 'SKELETON' and id <> 520;
     """
     sirius_db_engine.execute(insert_statement)
 


### PR DESCRIPTION
## Purpose

Prevent finance_person_id from being converted to float when loading invoices, ledger entries and fee reductions to Sirius.

## Approach

Add finance_invoice, finance_ledger and finance_remission_exemption to the list of special cases where certain columns need casting to a certain type - in this case finance_person_id to Int64

Remove the finance_person record from one of the persons on local/dev to ensure adequate test coverage

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
