### PR TITLE
Improve local log output

### DIFF
--- a/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
+++ b/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
@@ -1089,6 +1089,9 @@ def insert_client_address_data_into_sirius(db_config, sirius_db_engine):
 def insert_finance_person_data_into_sirius(db_config, sirius_db_engine):
     id = get_max_value(table="finance_person", column="id", db_config=db_config)
 
+    # Create a finance person for each person.
+    # Intentionally skip creating a finance person for person ID 520, to ensure that finance
+    # entities are still being migrated correctly even if there is no finance person to link them to.
     insert_statement = f"""
         INSERT INTO finance_person (id, person_id, finance_billing_reference, payment_method)
         SELECT

--- a/migration_steps/shared/custom_logger.py
+++ b/migration_steps/shared/custom_logger.py
@@ -1,11 +1,5 @@
-import inspect
-import json
-import os
 import logging
-import time
 from datetime import datetime
-import socket
-
 import colorlog as colourlog
 from pythonjsonlogger import jsonlogger
 
@@ -16,13 +10,8 @@ class MyHandler(colourlog.StreamHandler):
 
         colourlog.StreamHandler.__init__(self)
 
-        fmt = "%(log_color)s %(asctime)s %(filename)-18s %(levelname)-8s: %(message)s"
-
-        fmt_date = "%Y-%m-%dT%T%Z"
-
-        formatter = colourlog.ColoredFormatter(
-            fmt,
-            fmt_date,
+        formatter = CustomColouredFormatter(
+            datefmt="%Y-%m-%dT%T%Z",
             reset=True,
             log_colors={
                 "DEBUG": "cyan",
@@ -38,6 +27,20 @@ class MyHandler(colourlog.StreamHandler):
         )
 
         self.setFormatter(formatter)
+
+
+class CustomColouredFormatter(colourlog.ColoredFormatter):
+    def format(self, record: logging.LogRecord) -> str:
+        default_attrs = logging.LogRecord(None, None, None, None, None, None, None).__dict__.keys()
+        extras = set(record.__dict__.keys()) - default_attrs
+
+        fmt = "%(log_color)s %(asctime)s %(filename)-18s %(levelname)-8s: %(message)s"
+        for attr in extras:
+            fmt += f'; "{attr}": "%({attr})s"'
+
+        self._style._fmt = fmt
+
+        return super().format(record)
 
 
 class CustomJsonFormatter(jsonlogger.JsonFormatter):


### PR DESCRIPTION
## Purpose

Ensure that the console log output on local includes any `extra` data that was passed in to the logger.

Before:
<img width="964" alt="Screenshot 2021-11-02 at 14 00 08" src="https://user-images.githubusercontent.com/22475900/139861914-bdb2b69e-7a35-4c0a-a1f0-659b55068191.png">

After:
<img width="1242" alt="Screenshot 2021-11-02 at 13 54 59" src="https://user-images.githubusercontent.com/22475900/139861944-e345f411-787d-477f-b791-617ced39ab92.png">

## Approach

Loop over extra data params for each log message and add them to the format string.

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
