### PR TITLE
IN-996 Remove validation of annual_report_logs field which is not mapped

### DIFF
--- a/migration_steps/validation/validate_db/app/sql/fixed_sql/annual_report_logs.sql
+++ b/migration_steps/validation/validate_db/app/sql/fixed_sql/annual_report_logs.sql
@@ -25,8 +25,7 @@ INSERT INTO casrec_csv.exceptions_annual_report_logs(
                     NULLIF(account."Rcvd Date5", ''),
                     NULLIF(account."Rcvd Date6", '')
                 )
-            AS date) AS receiveddate,
-            CAST(NULLIF(account."Review Date", '') AS date) AS reviewdate
+            AS date) AS receiveddate
         FROM
             casrec_csv.account
      ) as csv_data
@@ -36,8 +35,7 @@ INSERT INTO casrec_csv.exceptions_annual_report_logs(
             annual_report_logs.reportingperiodenddate AS reportingperiodenddate,
             annual_report_logs.reportingperiodstartdate AS reportingperiodstartdate,
             annual_report_logs.duedate AS duedate,
-            annual_report_logs.receiveddate AS receiveddate,
-            annual_report_logs.reviewdate AS reviewdate
+            annual_report_logs.receiveddate AS receiveddate
         FROM
             {target_schema}.annual_report_logs
      ) as sirius_data


### PR DESCRIPTION
## Purpose

[IN-996](https://opgtransform.atlassian.net/browse/IN-996)

## Approach

Simple removal of SQL clause which validates migration of Review Date field, which is no longer validated.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [X] I have added relevant logging with appropriate levels to my code
* [X] I have updated documentation where relevant
* [X] I have added tests to prove my work
* [ ] The product team have tested these changes
