### PR TITLE
IN-1007 Use default description on client note when empty not null

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -771,7 +771,7 @@
         "casrec": {
             "from_table": "remarks",
             "transform": {
-                "description": "NULLIF({col}, 'no description migrated')"
+                "description": "CASE WHEN {col} = '' THEN 'no description migrated' ELSE {col} END"
             },
             "joins": [
                 "LEFT JOIN casrec_csv.pat ON casrec_csv.pat.\"Case\" = casrec_csv.remarks.\"Case\""


### PR DESCRIPTION
The fields were actually empty strings, not null, so the previous change wasn't working as intended.
