### PR TITLE
IN-995 Fix deputy_feepayer validation errors

### DIFF
--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -801,6 +801,9 @@ def main(team, staging):
     post_validation()
 
     if get_exception_count() > 0:
+        # TODO: remove conditional once all validation errors are fixed in preproduction
+        if environment in ["local", "development"]:
+            exit(1)
         log.info("Exceptions WERE found: override / continue anyway\n")
     else:
         log.info("No exceptions found: continue...\n")

--- a/migration_steps/validation/validate_db/app/sql/fixed_sql/deputy_feepayer_id.sql
+++ b/migration_steps/validation/validate_db/app/sql/fixed_sql/deputy_feepayer_id.sql
@@ -14,10 +14,13 @@ INSERT INTO casrec_csv.exceptions_deputy_feepayer_id(
         FROM casrec_csv.pat
         LEFT JOIN casrec_csv.deputyship
             ON deputyship."Case" = pat."Case"
+        LEFT JOIN casrec_csv.order
+            ON "order"."Order No" = deputyship."Order No"
         LEFT JOIN casrec_csv.deputy
             ON deputy."Deputy No" = deputyship."Deputy No"
         WHERE True
             AND deputy."Stat" = '1'
+            AND "order"."Ord Stat" <> 'Open'
             AND deputyship."Fee Payer" = 'Y'
             AND pat."Case" NOT IN (
                     '11065340',


### PR DESCRIPTION
## Purpose

Fix validation errors - 2 on local and 4 in pre.

## Approach

Update the validation SQL to exclude Open orders.

The conditional to exclude Open orders was applied recently to cases, which then broke this validation.

## Learning

Exiting on validation failure in local/dev will catch these errors and make them easier to fix.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
