### PR TITLE
In 1020b

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ workflows:
       - load_casrec_db:
           name: load casrec db preproduction
           requires: [build shared infra preproduction]
+          account: preproduction
           filters: {branches:{only:[master]}}
       - infrastructure:
           name: plan infra preproduction
@@ -345,8 +346,14 @@ workflows:
           cron: "30 07 * * *"
           filters: {branches:{only:[master]}}
     jobs:
+      - persist_parameters:
+          name: persist parameters development
+          param_workspace: development
+          environment_title: Development-Nightly
+          filters: {branches:{only:[master]}}
       - reset_sirius_full_restore:
           name: run and monitor jenkins restore job development
+          requires: [persist parameters development]
           sirius_environment: casmigrate
           filters: {branches:{only:[master]}}
 

--- a/terraform/environment/.terraform.lock.hcl
+++ b/terraform/environment/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.60.0"
+  version     = "3.60.0"
+  constraints = "3.60.0"
   hashes = [
     "h1:ngyTMQ2Zd+4GGkD3Ekrdnu97F1JzkK3SalbcazAVtlQ=",
     "zh:01323eedb8f006c8f9fffdfc23b449625b1446c1e43b8454e4a40a7461193661",

--- a/terraform/environment/cloud9.tf
+++ b/terraform/environment/cloud9.tf
@@ -30,3 +30,16 @@ data "aws_security_group" "cloud9" {
     ]
   }
 }
+
+// Access to frontend for Cloud9
+
+resource "aws_security_group_rule" "cloud9_to_frontend_sirius_ingress" {
+  count                    = local.account.name == "production" ? 0 : 1
+  type                     = "ingress"
+  protocol                 = "tcp"
+  description              = "Cloud9 direct access to frontend for manual API test runs"
+  from_port                = 80
+  to_port                  = 80
+  security_group_id        = data.aws_security_group.sirius_frontend.id
+  source_security_group_id = data.aws_security_group.cloud9.id
+}

--- a/terraform/environment/migration_command_role.tf
+++ b/terraform/environment/migration_command_role.tf
@@ -64,4 +64,39 @@ data "aws_iam_policy_document" "migration_commands" {
       "s3:*"
     ]
   }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:ListBucket",
+      "s3:getBucketVersioning"
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "states:ListActivities",
+      "states:ListStateMachines",
+      "states:ListTagsForResource",
+      "states:DescribeActivity",
+      "states:DescribeExecution",
+      "states:DescribeStateMachine",
+      "states:DescribeStateMachineForExecution",
+      "states:GetActivityTask",
+      "states:GetExecutionHistory"
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["arn:aws:states:eu-west-1:${local.account.account_id}:stateMachine:casrec-mig-state-machine-${local.account.name}"]
+    actions = [
+      "states:StartExecution",
+      "states:ListExecutions"
+    ]
+  }
 }

--- a/terraform/environment/state_machine.tf
+++ b/terraform/environment/state_machine.tf
@@ -113,7 +113,7 @@ locals {
                 "Overrides": {
                     "ContainerOverrides": [{
                         "Name": "etl0",
-                        "Command.$": "$.prep"
+                        "Command": ["prepare/prepare.sh"]
                     }]
                 }
             }
@@ -138,7 +138,7 @@ locals {
                 "Overrides": {
                     "ContainerOverrides": [{
                         "Name": "etl1",
-                        "Command.$": "$.load"
+                        "Command": ["python3", "load_casrec_schema/app/app.py"]
                     }]
                 }
             }
@@ -247,7 +247,7 @@ EOF
     "States": {
         "Prepare For Migration": {
             "Type": "Task",
-            "Next": "Parrallel Load Casrec",
+            "Next": "Copy Casrec Schema",
             "OutputPath": "$$.Execution.Input",
             "Resource": "arn:aws:states:::ecs:runTask.sync",
             "Parameters": {
@@ -265,128 +265,35 @@ EOF
                 "Overrides": {
                     "ContainerOverrides": [{
                         "Name": "etl0",
-                        "Command.$": "$.prep"
+                        "Command": ["prepare/prepare.sh"]
                     }]
                 }
             }
         },
-        "Parrallel Load Casrec": {
-            "Type": "Parallel",
+        "Copy Casrec Schema": {
+            "Type": "Task",
             "Next": "Run Transform Casrec",
-            "Branches": [
-                {
-                    "StartAt": "Run Load Casrec Task 1",
-                    "States": {
-                        "Run Load Casrec Task 1": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::ecs:runTask.sync",
-                            "Parameters": {
-                                "LaunchType": "FARGATE",
-                                "Cluster": "${aws_ecs_cluster.migration.arn}",
-                                "TaskDefinition": "${aws_ecs_task_definition.etl1.arn}",
-                                "NetworkConfiguration": {
-                                    "AwsvpcConfiguration": {
-                                        "Subnets": [${local.subnets_string}],
-                                        "SecurityGroups": ["${aws_security_group.etl.id}"],
-                                        "AssignPublicIp": "DISABLED"
-                                    }
-                                },
-                                "Overrides": {
-                                    "ContainerOverrides": [{
-                                        "Name": "etl1",
-                                        "Command.$": "$.load1"
-                                    }]
-                                }
-                            },
-                            "End": true
-                        }
+            "OutputPath": "$$.Execution.Input",
+            "Resource": "arn:aws:states:::ecs:runTask.sync",
+            "Parameters": {
+                "LaunchType": "FARGATE",
+                "PlatformVersion": "1.4.0",
+                "Cluster": "${aws_ecs_cluster.migration.arn}",
+                "TaskDefinition": "${aws_ecs_task_definition.etl1.arn}",
+                "NetworkConfiguration": {
+                    "AwsvpcConfiguration": {
+                        "Subnets": [${local.subnets_string}],
+                        "SecurityGroups": ["${aws_security_group.etl.id}"],
+                        "AssignPublicIp": "DISABLED"
                     }
                 },
-                {
-                    "StartAt": "Run Load Casrec Task 2",
-                    "States": {
-                        "Run Load Casrec Task 2": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::ecs:runTask.sync",
-                            "Parameters": {
-                                "LaunchType": "FARGATE",
-                                "Cluster": "${aws_ecs_cluster.migration.arn}",
-                                "TaskDefinition": "${aws_ecs_task_definition.etl1.arn}",
-                                "NetworkConfiguration": {
-                                    "AwsvpcConfiguration": {
-                                        "Subnets": [${local.subnets_string}],
-                                        "SecurityGroups": ["${aws_security_group.etl.id}"],
-                                        "AssignPublicIp": "DISABLED"
-                                    }
-                                },
-                                "Overrides": {
-                                    "ContainerOverrides": [{
-                                        "Name": "etl1",
-                                        "Command.$": "$.load2"
-                                    }]
-                                }
-                            },
-                            "End": true
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Run Load Casrec Task 3",
-                    "States": {
-                        "Run Load Casrec Task 3": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::ecs:runTask.sync",
-                            "Parameters": {
-                                "LaunchType": "FARGATE",
-                                "Cluster": "${aws_ecs_cluster.migration.arn}",
-                                "TaskDefinition": "${aws_ecs_task_definition.etl1.arn}",
-                                "NetworkConfiguration": {
-                                    "AwsvpcConfiguration": {
-                                        "Subnets": [${local.subnets_string}],
-                                        "SecurityGroups": ["${aws_security_group.etl.id}"],
-                                        "AssignPublicIp": "DISABLED"
-                                    }
-                                },
-                                "Overrides": {
-                                    "ContainerOverrides": [{
-                                        "Name": "etl1",
-                                        "Command.$": "$.load3"
-                                    }]
-                                }
-                            },
-                            "End": true
-                        }
-                    }
-                },
-                {
-                    "StartAt": "Run Load Casrec Task 4",
-                    "States": {
-                        "Run Load Casrec Task 4": {
-                            "Type": "Task",
-                            "Resource": "arn:aws:states:::ecs:runTask.sync",
-                            "Parameters": {
-                                "LaunchType": "FARGATE",
-                                "Cluster": "${aws_ecs_cluster.migration.arn}",
-                                "TaskDefinition": "${aws_ecs_task_definition.etl1.arn}",
-                                "NetworkConfiguration": {
-                                    "AwsvpcConfiguration": {
-                                        "Subnets": [${local.subnets_string}],
-                                        "SecurityGroups": ["${aws_security_group.etl.id}"],
-                                        "AssignPublicIp": "DISABLED"
-                                    }
-                                },
-                                "Overrides": {
-                                    "ContainerOverrides": [{
-                                        "Name": "etl1",
-                                        "Command.$": "$.load4"
-                                    }]
-                                }
-                            },
-                            "End": true
-                        }
-                    }
+                "Overrides": {
+                    "ContainerOverrides": [{
+                        "Name": "etl1",
+                        "Command": ["python3", "load_casrec_schema/app/app.py"]
+                    }]
                 }
-            ]
+            }
         },
         "Run Transform Casrec": {
             "Type": "Task",

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = "3.60.0"
+  }
+}

--- a/terraform/shared/.terraform.lock.hcl
+++ b/terraform/shared/.terraform.lock.hcl
@@ -2,7 +2,8 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version = "3.60.0"
+  version     = "3.60.0"
+  constraints = "3.60.0"
   hashes = [
     "h1:ngyTMQ2Zd+4GGkD3Ekrdnu97F1JzkK3SalbcazAVtlQ=",
     "zh:01323eedb8f006c8f9fffdfc23b449625b1446c1e43b8454e4a40a7461193661",

--- a/terraform/shared/state_machine.tf
+++ b/terraform/shared/state_machine.tf
@@ -36,7 +36,7 @@ locals {
                 "Overrides": {
                     "ContainerOverrides": [{
                         "Name": "prepare",
-                        "Command.$": "$.prep"
+                        "Command": ["prepare/prepare_load_casrec_db.sh"]
                     }]
                 }
             }
@@ -65,7 +65,7 @@ locals {
                                 "Overrides": {
                                     "ContainerOverrides": [{
                                         "Name": "load-casrec-db",
-                                        "Command.$": "$.load1"
+                                        "Command": ["python3","load_casrec/app/app.py","--skip_load=false","--delay=0"]
                                     }]
                                 }
                             },
@@ -93,7 +93,7 @@ locals {
                                 "Overrides": {
                                     "ContainerOverrides": [{
                                         "Name": "load-casrec-db",
-                                        "Command.$": "$.load2"
+                                        "Command": ["python3","load_casrec/app/app.py","--skip_load=false","--delay=2"]
                                     }]
                                 }
                             },
@@ -121,7 +121,7 @@ locals {
                                 "Overrides": {
                                     "ContainerOverrides": [{
                                         "Name": "load-casrec-db",
-                                        "Command.$": "$.load3"
+                                        "Command": ["python3","load_casrec/app/app.py","--skip_load=false","--delay=3"]
                                     }]
                                 }
                             },
@@ -149,7 +149,7 @@ locals {
                                 "Overrides": {
                                     "ContainerOverrides": [{
                                         "Name": "load-casrec-db",
-                                        "Command.$": "$.load4"
+                                        "Command": ["python3","load_casrec/app/app.py","--skip_load=false","--delay=4"]
                                     }]
                                 }
                             },

--- a/terraform/shared/versions.tf
+++ b/terraform/shared/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    aws = "3.60.0"
+  }
+}


### PR DESCRIPTION
## Purpose

Fix a number of issues with our infra...

Allow migration.command user to upload spreadsheets to only our s3 bucket through GUI
Allow migration.command user to kick off only our step functions through GUI
Update wait on the step function runner to allow logs to finish filtering through
Update firewall rules to allow frontend from cloud9
Get rid of data post from step functions as we don't really need it any more now that we have split this bit out and it makes it confusing for devs to run the step functions.
Fix missing account on load_casrec stage!
Add persist parameters to 

Does not include this any more... Will do as separate PRs:
Bring in state files and incorporate the previous mappings repo into our shared repo.
Move cloud9 from environment to shared (may just not do this tbh)
Upgrade terraform version and provider versions

## Approach

All straight forward changes that I had ready to go Friday morning. Booked in a slot to do the state moves at 4. Bringing in other repo was fine but moving the cloud9 ended up going horribly with it refusing to delete the instance and then not being able to check that no one had important work on pre as it was too late so backed it all out again...

## Learning

Do smaller PRs... already knew this but was chancing it. Not good. 

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
