### PR TITLE
IN-1028 add new elastic reset

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,11 @@ workflows:
           tf_workspace: development
           runner_command: functional-api-tests
           filters: {branches:{ignore:[master]}}
+      - run_elasticsearch_reset:
+          name: full reindex elasticsearch development
+          requires: [run functional api tests]
+          tf_workspace: development
+          filters: {branches:{ignore:[master]}}
       - job_complete:
           name: job complete notification
           requires: [run functional api tests]
@@ -246,11 +251,6 @@ workflows:
           wait_for: "18000"
           tf_workspace: preqa
           filters: {branches:{only:[master]}}
-      - run_api_tests:
-          name: run api tests preqa
-          requires: [run the step function preqa]
-          tf_workspace: preqa
-          filters: {branches:{only:[master]}}
       - run_elasticsearch_reset:
           name: full reindex elasticsearch preqa
           requires: [run the step function preqa]
@@ -258,7 +258,7 @@ workflows:
           filters: {branches:{only:[master]}}
       - job_complete:
           name: job complete notification
-          requires: [run api tests preqa]
+          requires: [run the step function preqa]
           workspace: preqa
           filters: {branches:{only:[master]}}
   qa:
@@ -385,14 +385,9 @@ workflows:
           tf_command: apply
           folder: shared
           filters: {branches:{only:[master]}}
-      - load_casrec_db:
-          name: load casrec db preproduction
-          requires: [build shared infra preproduction]
-          account: preproduction
-          filters: {branches:{only:[master]}}
       - infrastructure:
           name: build infra preproduction
-          requires: [get latest tag preproduction]
+          requires: [build shared infra preproduction]
           tf_workspace: preproduction
           tf_command: apply
           filters: {branches:{only:[master]}}
@@ -400,8 +395,7 @@ workflows:
           name: run the step function preproduction
           requires: [
             run and monitor jenkins restore job pre,
-            build infra preproduction,
-            load casrec db preproduction
+            build infra preproduction
           ]
           account: "preproduction"
           wait_for: "18000"
@@ -423,25 +417,10 @@ workflows:
           requires: [run api tests preproduction]
           tf_workspace: preproduction
           filters: {branches:{only:[master]}}
-      - approve:
-          name: approve qa kick off
-          type: approval
-          requires: [tag image for qa]
-          filters: {branches:{only:[master]}}
-      - kick_off_environment:
-          name: kick off qa
-          workspace: qa
-          requires: [approve qa kick off]
-          filters: {branches:{only:[master]}}
-      - approve:
-          name: approve preqa kick off
-          type: approval
-          requires: [tag image for qa]
-          filters: {branches:{only:[master]}}
       - kick_off_environment:
           name: kick off preqa
           workspace: preqa
-          requires: [approve preqa kick off]
+          requires: [run api tests preproduction]
           filters: {branches:{only:[master]}}
       - job_complete:
           name: job complete notification
@@ -449,54 +428,6 @@ workflows:
           workspace: preproduction
           filters: {branches:{only:[master]}}
 
-  nightly_preqa_run:
-    triggers:
-      - schedule:
-          cron: "10 07 * * *"
-          filters: {branches:{only:[master]}}
-    jobs:
-      - persist_parameters:
-          name: persist parameters preqa
-          param_workspace: preqa
-          environment_title: PreQA-Nightly
-          filters: {branches:{only:[master]}}
-      - get_latest_image:
-          name: get latest tag preqa
-          check_preprod_run: true
-          requires: [persist parameters preqa]
-          image_tag: qa
-          filters: {branches:{only:[master]}}
-      - reset_sirius_full_restore:
-          name: run and monitor jenkins restore job preqa
-          requires: [get latest tag preqa]
-          sirius_environment: casrecdmpq
-          filters: {branches:{only:[master]}}
-      - infrastructure:
-          name: build infra preqa
-          requires: [get latest tag preqa]
-          tf_workspace: preqa
-          tf_command: apply
-          filters: {branches:{only:[master]}}
-      - run_step_function:
-          name: run the step function preqa
-          requires: [
-            run and monitor jenkins restore job preqa,
-            build infra preqa
-          ]
-          account: "preqa"
-          wait_for: "18000"
-          tf_workspace: preqa
-          filters: {branches:{only:[master]}}
-      - run_elasticsearch_reset:
-          name: full reindex elasticsearch preqa
-          requires: [run the step function preqa]
-          tf_workspace: preqa
-          filters: {branches:{only:[master]}}
-      - job_complete:
-          name: job complete notification
-          requires: [run the step function preqa]
-          workspace: preqa
-          filters: {branches:{only:[master]}}
 
 orbs:
   aws-cli: circleci/aws-cli@1.3.0
@@ -1027,6 +958,7 @@ jobs:
       - run:
           name: Run API tests
           command: ecs-runner -task ${RUNNER_CMD} -timeout 600
+          no_output_timeout: 30m
       - notififications/notify_env_vars
       - notififications/notify_if_fail
   run_behat_tests:
@@ -1068,7 +1000,7 @@ jobs:
       - terraform/setup_ecs_runner
       - run:
           name: Reset Elasticsearch
-          command: ecs-runner -task elasticsearch-reindex -timeout 18000
+          command: ecs-runner -task reindex-elasticsearch-by-date -timeout 18000
           background: true
       - run:
           name: elasticsearch

--- a/terraform/environment/sirius_tasks.toml
+++ b/terraform/environment/sirius_tasks.toml
@@ -184,6 +184,21 @@
         },
         "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/reset-elasticsearch-${cluster}"
       },
+      "reindex-elasticsearch-by-date": {
+        "Cluster": "${cluster}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "SecurityGroups": [
+              "${sec_group}"
+            ],
+            "Subnets": [
+              "${subnets}"
+            ]
+          }
+        },
+        "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/reindex-elasticsearch-by-date-${cluster}"
+      },
       "elasticsearch-reindex": {
         "Cluster": "${cluster}",
         "LaunchType": "FARGATE",


### PR DESCRIPTION
## Purpose

Use the new elastic reset (and change a couple of other pipeline bits...)

## Approach

Switching elastic is a simple switch of the name (did a test in dev to check it works)

Now that we have a preprod that should consistently work, I've decided to just get rid of the nightly preqa and have it kick off from the back of preprod. Really it was only supposed to be a temp workaround to other issues that we had it running separately. Got rid of the load casrec bit from pre as tbh it's not picking up s3 changes currently and we have it running in dev every run that checks the functionality isn't broken. So really it's just an extra step we can remove for now.

Added an extended timeout for api tests.
 
## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
