### PR TITLE
IN-1033 make batch number updates faster

### DIFF
--- a/migration_steps/load_to_sirius/post_migration_db_tasks/finance_batch_numbers.py
+++ b/migration_steps/load_to_sirius/post_migration_db_tasks/finance_batch_numbers.py
@@ -65,6 +65,8 @@ def set_batch_numbers_in_finance_person(cursor):
     batch_number = create_batch_number(cursor=cursor)
 
     log.info(f"Setting batch number {batch_number} in finance_person...")
+    query = "SET random_page_cost = 1;"
+    cursor.execute(query)
     query = f"""
         UPDATE finance_person
         SET batchnumber = {batch_number}
@@ -74,6 +76,8 @@ def set_batch_numbers_in_finance_person(cursor):
         AND persons.clientsource = 'CASRECMIGRATION'
         AND finance_person.batchnumber IS NULL;
     """
+    cursor.execute(query)
+    query = "SET random_page_cost = default;"
     cursor.execute(query)
 
 

--- a/migration_steps/validation/api_test_data_s3_upload/app/validation/api_test_csvs/deputy_notes.csv
+++ b/migration_steps/validation/api_test_data_s3_upload/app/validation/api_test_csvs/deputy_notes.csv
@@ -1,4 +1,4 @@
 endpoint,entity_ref,json_locator,test_purpose,api_response
 /api/v1/deputy/{id}/notes,10050512,["noteType"],dev_api_tests,EVENT_CREATED|EVENT_CREATED
 /api/v1/deputy/{id}/notes,10051890,["direction"],dev_api_tests,INTERNAL|INTERNAL
-/api/v1/deputy/{id}/notes,10053723,["createdTime"],dev_api_tests,11/10/2016 01:00:00|11/10/2016 01:00:00
+/api/v1/deputy/{id}/notes,10053723,["createdTime"],dev_api_tests,11/10/2016 10:23:41|11/10/2016 10:23:41

--- a/scripts/api_tests_generator/preprod_cases/visits.csv
+++ b/scripts/api_tests_generator/preprod_cases/visits.csv
@@ -1,6 +1,8 @@
 endpoint,entity_ref,json_locator,test_purpose
+/api/v1/clients/{id}/visits,10001403,["visitType"]["label"],visit_type_ass
+/api/v1/clients/{id}/visits,10135295,["visitType"]["label"],visit_type_inv
 /api/v1/clients/{id}/visits,10000037,["visitType"]["label"],visit_type_sup
-/api/v1/clients/{id}/visits,12635676,["visitType"]["label"],visit_type_null
+/api/v1/clients/{id}/visits,11263970,["visitType"]["label"],visit_type_null
 /api/v1/clients/{id}/visits,10000037,["visitOutcome"]["label"],visit_outcome_aborted
 /api/v1/clients/{id}/visits,10012643,["visitOutcome"]["label"],visit_outcome_cancelled
 /api/v1/clients/{id}/visits,10001403,["visitOutcome"]["label"],visit_outcome_successful
@@ -17,10 +19,10 @@ endpoint,entity_ref,json_locator,test_purpose
 /api/v1/clients/{id}/visits,10001668,["visitSubType"]["label"],visit_sub_type_med
 /api/v1/clients/{id}/visits,10035792,["visitSubType"]["label"],visit_sub_type_pa
 /api/v1/clients/{id}/visits,10000037,["visitSubType"]["label"],visit_sub_type_pro
-/api/v1/clients/{id}/visits,10087622,["visitSubType"]["label"],visit_sub_type_null
+/api/v1/clients/{id}/visits,11263970,["visitSubType"]["label"],visit_sub_type_null
 /api/v1/clients/{id}/visits,10000037,["whoToVisit"]["label"],who_to_visit_client
 /api/v1/clients/{id}/visits,10004038,["whoToVisit"]["label"],who_to_visit_deputy
-/api/v1/clients/{id}/visits,12587836,["whoToVisit"]["label"],who_to_visit_null
+/api/v1/clients/{id}/visits,13217597,["whoToVisit"]["label"],who_to_visit_null
 /api/v1/clients/{id}/visits,10001403,["visitCancellationReason"]["label"],visit_cancellation_reason_area
 /api/v1/clients/{id}/visits,10004188,["visitCancellationReason"]["label"],visit_cancellation_reason_canc
 /api/v1/clients/{id}/visits,10008039,["visitCancellationReason"]["label"],visit_cancellation_reason_conf


### PR DESCRIPTION
## Purpose

Fix batch number update taking a very long time..

Also to save a PR, update with some API fixes we've seen based on sorting out API tests.

## Approach

Looked at QEP for the query to update batch numbers and saw it was doing scans and ignoring the index on persons table. This is often due to bad statistics meaning it makes bad decisions..  Like it believes the table is small enough that scan would be more efficient. We can trick it by telling it that seeks are way cheaper and then it uses the index correctly and takes like 3 seconds instead of an hour and half to update... (tested in preprod)

## Learning

How to look at QEPs in postgres.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
