### PR TITLE
IN-1032 Fix client_notes validation error

### DIFF
--- a/migration_steps/load_casrec_schema/app/app.py
+++ b/migration_steps/load_casrec_schema/app/app.py
@@ -29,9 +29,10 @@ def copy_casrec_schema():
     copy_schema(
         log=log,
         sql_path=sql_path,
-        from_config=config.db_config["casrec"],
+        config=config,
+        from_db="casrec",
         from_schema=config.schemas["pre_transform"],
-        to_config=config.db_config["migration"],
+        to_db="migration",
         to_schema=config.schemas["pre_transform"],
     )
 

--- a/migration_steps/prepare/create_stage_schema/app/app.py
+++ b/migration_steps/prepare/create_stage_schema/app/app.py
@@ -46,9 +46,10 @@ def main():
     copy_schema(
         log=log,
         sql_path=shared_sql_path,
-        from_config=config.db_config["target"],
+        config=config,
+        from_db="target",
         from_schema=config.schemas["public"],
-        to_config=config.db_config["migration"],
+        to_db="migration",
         to_schema=config.schemas["pre_migration"],
         structure_only=True,
     )

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -660,9 +660,10 @@ def pre_validation():
         copy_schema(
             log=log,
             sql_path=sql_path,
-            from_config=config.db_config["migration"],
+            config=config,
+            from_db="migration",
             from_schema=config.schemas["pre_transform"],
-            to_config=config.db_config["target"],
+            to_db="target",
             to_schema=config.schemas["pre_transform"],
         )
     else:


### PR DESCRIPTION
## Purpose

Fixes the last remaining client_notes validation error, but more importantly fixes some dodgy string replacements

## Approach

Rename the schema name prior to exporting it, so that we won't have to rename it with find&replace in the SQL dump file.

Other string replacements (like the SQL user/owner) were made a lot more specific using regex.

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
