### PR TITLE
IN-1009 validation tweak to allow for null warningtext

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -428,7 +428,7 @@
                 "persons.type = 'actor_client'",
                 "persons.clientsource = 'CASRECMIGRATION'",
                 "warnings.warningtype = 'Other'",
-                "warnings.warningtext NOT IN ('Casrec Migration - SAAR Check Warning', 'Casrec Migration - No Debt to be chased')"
+                "(warnings.warningtext NOT IN ('Casrec Migration - SAAR Check Warning', 'Casrec Migration - No Debt to be chased') OR warnings.warningtext IS NULL)"
             ]
         },
         "manual_checks": {


### PR DESCRIPTION
## Purpose

Improvement to validation. The migration was fine but the validation showed 1 row discrepancy

## Approach

NULL warningtext isn't caught by the IN() statement, so adjust the where clause

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
