### PR TITLE
IN-1058 Delete tasks not linked to a Pilot One case

### DIFF
--- a/migration_steps/integration/copy_from_sirius/app/utilities/copy_tables.py
+++ b/migration_steps/integration/copy_from_sirius/app/utilities/copy_tables.py
@@ -27,7 +27,7 @@ def copy_tables(db_config, source_db_engine, target_db_engine, tables):
         log.info(f"Copying {table} ({', '.join(cols)}) from Sirius to Staging")
 
         source_data_query = generate_select_query(
-            db_config["sirius_schema"], table, cols
+            schema=db_config["sirius_schema"], table=table, columns=cols, order_by=None
         )
         source_data_df = pd.read_sql_query(con=source_db_engine, sql=source_data_query)
 

--- a/migration_steps/prepare/create_skeleton_data/app/lookups/dev_data_fixes.py
+++ b/migration_steps/prepare/create_skeleton_data/app/lookups/dev_data_fixes.py
@@ -50,20 +50,28 @@ def amend_dev_assignees(db_engine):
         479,
         480,
     ]
-    teams = [f"({team_id}, 'Migration Team', 'assignee_team')" for team_id in team_ids]
+    teams = [f"({team_id}, 'Migration Team {team_id}', 'assignee_team', 'ALLOCATIONS')" for team_id in team_ids]
     users = [
-        f"({user_id}, 'Migration User', 'assignee_user')"
+        f"({user_id}, 'Migration User', 'assignee_user', null)"
         for user_id in assignee_ids
         if user_id not in team_ids
     ]
     assignees = teams + users
 
+    # assign all users to team ID 100, for dev testing purposes
+    user_teams = [f"(100, {user_id})" for user_id in assignee_ids if user_id not in team_ids]
+
     sql = f"""
-        INSERT INTO public.assignees (id, name, type)
+        INSERT INTO public.assignees (id, name, type, teamtype)
         VALUES {",".join(assignees)}
         ON CONFLICT (id) DO UPDATE
             SET name = excluded.name,
-                type = excluded.type;
+                type = excluded.type,
+                teamtype = excluded.teamtype;
+        
+        INSERT INTO assignee_teams (team_id, assignablecomposite_id)
+        VALUES {",".join(user_teams)}
+        ON CONFLICT ON CONSTRAINT assignee_teams_pkey DO NOTHING;
     """
 
     try:

--- a/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
+++ b/migration_steps/prepare/create_skeleton_data/app/skeleton_data.py
@@ -1090,8 +1090,6 @@ def insert_finance_person_data_into_sirius(db_config, sirius_db_engine):
     id = get_max_value(table="finance_person", column="id", db_config=db_config)
 
     # Create a finance person for each person.
-    # Intentionally skip creating a finance person for person ID 520, to ensure that finance
-    # entities are still being migrated correctly even if there is no finance person to link them to.
     insert_statement = f"""
         INSERT INTO finance_person (id, person_id, finance_billing_reference, payment_method)
         SELECT
@@ -1099,7 +1097,7 @@ def insert_finance_person_data_into_sirius(db_config, sirius_db_engine):
             id as person_id,
             row_number() over () + 990000 as finance_billing_reference,
             'DEMANDED'
-        from persons where clientsource = 'SKELETON' and id <> 520;
+        from persons where clientsource = 'SKELETON';
     """
     sirius_db_engine.execute(insert_statement)
 

--- a/migration_steps/prepare/delete_existing_data/sql/delete_statements.sql
+++ b/migration_steps/prepare/delete_existing_data/sql/delete_statements.sql
@@ -201,6 +201,16 @@ INNER JOIN deletions.base_clients_persons bcp ON bcp.id = c.client_id;
 
 CREATE UNIQUE INDEX deputy_tasks_id_idx ON deletions.deletions_deputy_tasks (id);
 
+CREATE TABLE IF NOT EXISTS deletions.deletions_case_tasks (id int);
+INSERT INTO deletions.deletions_case_tasks (id)
+SELECT t.id
+FROM tasks t
+INNER JOIN caseitem_task ct ON t.id = ct.task_id
+INNER JOIN cases c ON ct.caseitem_id = c.id
+INNER JOIN deletions.base_clients_persons bcp ON bcp.id = c.client_id;
+
+CREATE UNIQUE INDEX case_tasks_id_idx ON deletions.deletions_case_tasks (id);
+
 CREATE TABLE IF NOT EXISTS deletions.deletions_deputy_documents (id int);
 INSERT INTO deletions.deletions_deputy_documents (id)
 SELECT d.id
@@ -333,6 +343,11 @@ WHERE task_id in (
     select id FROM deletions.deletions_client_tasks
 );
 
+UPDATE documents SET task_id = NULL
+WHERE task_id in (
+    select id FROM deletions.deletions_case_tasks
+);
+
 DELETE FROM complaints a
 USING deletions.deletions_client_complaints b
 WHERE a.id = b.id;
@@ -415,6 +430,10 @@ WHERE a.id = b.id;
 
 DELETE FROM tasks a
 USING deletions.deletions_deputy_tasks b
+WHERE a.id = b.id;
+
+DELETE FROM tasks a
+USING deletions.deletions_case_tasks b
 WHERE a.id = b.id;
 
 DELETE FROM person_task a

--- a/migration_steps/shared/tables_to_copy_from_sirius.json
+++ b/migration_steps/shared/tables_to_copy_from_sirius.json
@@ -73,6 +73,29 @@
 			"data_type": "str",
 			"table_name": "assignees",
 			"entity": ""
+		},
+		"teamtype": {
+			"is_pk": "",
+			"fk_parents": "",
+			"data_type": "str",
+			"table_name": "assignees",
+			"entity": ""
+		}
+	},
+	"assignee_teams": {
+		"team_id": {
+			"is_pk": "",
+			"fk_parents": "",
+			"data_type": "int",
+			"table_name": "assignee_teams",
+			"entity": ""
+		},
+		"assignablecomposite_id": {
+			"is_pk": "",
+			"fk_parents": "",
+			"data_type": "int",
+			"table_name": "assignee_teams",
+			"entity": ""
 		}
 	}
 }


### PR DESCRIPTION
## Purpose

Fix for IN-1058 - Tasks not showing in Sirius Dashboard.

The tasks in question were "case tasks" i.e. linked to a specific case rather than a person. The cases were (rightly) deleted by our deletion script as they weren't Pilot One, which then left the tasks not linked to anything, hence causing an error on the front-end.

## Approach

Delete case tasks that are not linked to a Pilot One case.

Also allocate all users on dev to a team (team ID 100), so that we can see all migrated taks on the Dashboard locally by selecting "My team's tasks" in the filter

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
