### PR TITLE
In 1052 Entity counts validation

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,6 +20,7 @@ services:
       - ./migration_steps/prepare/prepare_load_casrec_db.sh:/prepare/prepare_load_casrec_db.sh
       - ./migration_steps/prepare/filter_data:/prepare/filter_data
       - ./migration_steps/prepare/prepare_source:/prepare/prepare_source
+      - ./migration_steps/prepare/counts_verification:/prepare/counts_verification
       - ./migration_steps/prepare/create_stage_schema:/prepare/create_stage_schema
       - ./migration_steps/prepare/case_details_to_s3:/prepare/case_details_to_s3
       - ./migration_steps/prepare/create_skeleton_data:/prepare/create_skeleton_data

--- a/migrate.sh
+++ b/migrate.sh
@@ -103,6 +103,7 @@ cat docker_load.log
 rm docker_load.log
 echo "=== Step 0 - Filter data ==="
 docker-compose ${COMPOSE_ARGS} run --rm prepare python3 /prepare/filter_data/app/app.py --correfs="${CORREFS}"
+docker-compose ${COMPOSE_ARGS} run --rm prepare python3 /prepare/counts_verification/count_casrec_source.py
 echo "=== Step 1 - Transform ==="
 docker-compose ${COMPOSE_ARGS} run --rm transform_casrec transform_casrec/transform.sh --correfs="${CORREFS}"
 echo "=== Step 2 - Integrate with Sirius ==="

--- a/migrate.sh
+++ b/migrate.sh
@@ -118,6 +118,8 @@ echo "=== Step 6 - API Tests ==="
 docker-compose ${COMPOSE_ARGS} run --rm validation validation/api_tests.sh
 echo "=== Step 7 - Functional API Tests ==="
 docker-compose ${COMPOSE_ARGS} run --rm validation validation/functional_api_tests.sh
+echo "=== Step 8 - Final Counts ==="
+docker-compose ${COMPOSE_ARGS} run --rm prepare python3 /prepare/counts_verification/count_final.py
 
 if [ "${GENERATE_DOCS}" == "true" ]
   then

--- a/migration_steps/prepare-dockerfile
+++ b/migration_steps/prepare-dockerfile
@@ -8,5 +8,6 @@ COPY prepare/create_stage_schema /prepare/create_stage_schema
 COPY prepare/case_details_to_s3 /prepare/case_details_to_s3
 COPY prepare/create_skeleton_data /prepare/create_skeleton_data
 COPY prepare/delete_existing_data /prepare/delete_existing_data
+COPY prepare/counts_verification /prepare/counts_verification
 COPY shared /shared
 CMD ["echo", "NO_OP"]

--- a/migration_steps/prepare/counts_verification/count_casrec_source.py
+++ b/migration_steps/prepare/counts_verification/count_casrec_source.py
@@ -41,7 +41,7 @@ def main(correfs):
         f"Enabled features: {', '.join(config.enabled_feature_flags(environment))}"
     )
     log.info(log_title(message="Begin"))
-    conn_target = psycopg2.connect(config.get_db_connection_string("target"))
+    conn_target = psycopg2.connect(config.get_db_connection_string("migration"))
     execute_sql_file(current_path / "sql", "count_casrec_source.sql", conn_target)
     log.info(f"Updated count record with source data counts.")
 

--- a/migration_steps/prepare/counts_verification/count_casrec_source.py
+++ b/migration_steps/prepare/counts_verification/count_casrec_source.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import logging.config
+import time
+import psycopg2
+import custom_logger
+from dotenv import load_dotenv
+import click
+import helpers
+from db_helpers import execute_sql_file
+from helpers import log_title
+
+env_path = current_path / "../../.env"
+load_dotenv(dotenv_path=env_path)
+environment = os.environ.get("ENVIRONMENT")
+config = helpers.get_config(env=environment)
+
+custom_logger.setup_logging(
+    env=environment,
+    module_name="count casrec source data",
+)
+log = logging.getLogger("root")
+config.custom_log_level()
+
+@click.command()
+@click.option("--correfs", default="")
+def main(correfs):
+    allowed_entities = config.allowed_entities(env=environment)
+    filtered_correfs = config.get_filtered_correfs(environment, correfs)
+
+    log.info(log_title(message="Migration Step: Count Casrec source data"))
+    log.debug(f"Environment: {environment}")
+    log.info(f"Correfs: {', '.join(filtered_correfs) if filtered_correfs else 'all'}")
+    log.info(f"Enabled entities: {', '.join(allowed_entities)}")
+    log.info(
+        f"Enabled features: {', '.join(config.enabled_feature_flags(environment))}"
+    )
+    log.info(log_title(message="Begin"))
+    conn_target = psycopg2.connect(config.get_db_connection_string("target"))
+    execute_sql_file(current_path / "sql", "count_casrec_source.sql", conn_target)
+    log.info(f"Updated count record with source data counts.")
+
+
+if __name__ == "__main__":
+    t = time.process_time()
+
+    main()
+
+    print(f"Total time: {round(time.process_time() - t, 2)}")

--- a/migration_steps/prepare/counts_verification/count_existing_pc1.py
+++ b/migration_steps/prepare/counts_verification/count_existing_pc1.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import logging.config
+import time
+import psycopg2
+import custom_logger
+from dotenv import load_dotenv
+import click
+import helpers
+from db_helpers import execute_sql_file
+from helpers import log_title
+
+env_path = current_path / "../../.env"
+load_dotenv(dotenv_path=env_path)
+environment = os.environ.get("ENVIRONMENT")
+config = helpers.get_config(env=environment)
+
+custom_logger.setup_logging(
+    env=environment,
+    module_name="count pre-existing client-pilot-one data on sirius",
+)
+log = logging.getLogger("root")
+config.custom_log_level()
+
+@click.command()
+@click.option("--correfs", default="")
+def main(correfs):
+    allowed_entities = config.allowed_entities(env=environment)
+    filtered_correfs = config.get_filtered_correfs(environment, correfs)
+
+    log.info(log_title(message="Migration Step: Count Existing Client Pilot One data on target"))
+    log.debug(f"Environment: {environment}")
+    log.info(f"Correfs: {', '.join(filtered_correfs) if filtered_correfs else 'all'}")
+    log.info(f"Enabled entities: {', '.join(allowed_entities)}")
+    log.info(
+        f"Enabled features: {', '.join(config.enabled_feature_flags(environment))}"
+    )
+    log.info(log_title(message="Begin"))
+    conn_target = psycopg2.connect(config.get_db_connection_string("target"))
+    execute_sql_file(current_path / "sql", "count_existing_pc1.sql", conn_target)
+    log.info(f"Updated count record with pre-existing Client Pilot One counts from Sirius.")
+
+
+if __name__ == "__main__":
+    t = time.process_time()
+
+    main()
+
+    print(f"Total time: {round(time.process_time() - t, 2)}")

--- a/migration_steps/prepare/counts_verification/count_final.py
+++ b/migration_steps/prepare/counts_verification/count_final.py
@@ -1,0 +1,63 @@
+import os
+import sys
+from pathlib import Path
+
+current_path = Path(os.path.dirname(os.path.realpath(__file__)))
+sys.path.insert(0, str(current_path) + "/../../../shared")
+
+import logging.config
+import time
+import psycopg2
+import custom_logger
+from dotenv import load_dotenv
+import click
+import helpers
+from db_helpers import execute_sql_file
+from helpers import log_title
+import pandas as pd
+from tabulate import tabulate
+
+env_path = current_path / "../../.env"
+load_dotenv(dotenv_path=env_path)
+environment = os.environ.get("ENVIRONMENT")
+config = helpers.get_config(env=environment)
+
+custom_logger.setup_logging(
+    env=environment,
+    module_name="count pre-existing client-pilot-one data on sirius",
+)
+log = logging.getLogger("root")
+config.custom_log_level()
+
+@click.command()
+@click.option("--correfs", default="")
+def main(correfs):
+    allowed_entities = config.allowed_entities(env=environment)
+    filtered_correfs = config.get_filtered_correfs(environment, correfs)
+
+    log.info(log_title(message="Migration Step: Count final migrated rows"))
+    log.debug(f"Environment: {environment}")
+    log.info(f"Correfs: {', '.join(filtered_correfs) if filtered_correfs else 'all'}")
+    log.info(f"Enabled entities: {', '.join(allowed_entities)}")
+    log.info(
+        f"Enabled features: {', '.join(config.enabled_feature_flags(environment))}"
+    )
+    log.info(log_title(message="Begin"))
+    conn_target = psycopg2.connect(config.get_db_connection_string("target"))
+    execute_sql_file(current_path / "sql", "count_final.sql", conn_target)
+    log.info(f"Updated count record with final counts form Sirius")
+    df = pd.read_sql(
+        sql = "SELECT * FROM countverification.counts ORDER BY supervision_table;",
+        con=conn_target
+    )
+    headers = ["Supervision Table", "CP1 Existing", "Casrec", "Expected", "Final Count", "Result"]
+    report_table = tabulate(df, headers, tablefmt="psql")
+    print(report_table)
+
+
+if __name__ == "__main__":
+    t = time.process_time()
+
+    main()
+
+    print(f"Total time: {round(time.process_time() - t, 2)}")

--- a/migration_steps/prepare/counts_verification/sql/count_casrec_source.sql
+++ b/migration_steps/prepare/counts_verification/sql/count_casrec_source.sql
@@ -12,8 +12,8 @@ CREATE TABLE IF NOT EXISTS countverification.filtered_orders (
 );
 INSERT INTO countverification.filtered_orders ("Order No", "Case")
 SELECT "Order No", "Case" FROM casrec_csv.order WHERE "Ord Stat" != 'Open';
-CREATE UNIQUE INDEX countver_filteredorder_orderno_idx ON countverification.filtered_orders ("Order No");
-CREATE INDEX countver_filteredorder_case_idx ON countverification.filtered_orders ("Case");
+CREATE UNIQUE INDEX filteredorder_orderno_idx ON countverification.filtered_orders ("Order No");
+CREATE INDEX filteredorder_case_idx ON countverification.filtered_orders ("Case");
 
 -- We are only migrating deputies linked to cases
 -- so, this is all deputies linked to a deputyship on a case as above
@@ -25,10 +25,7 @@ FROM casrec_csv.deputy dep
         ON ds."Deputy No" = dep."Deputy No"
     INNER JOIN countverification.filtered_orders o
         ON o."Order No" = ds."Order No";
-CREATE UNIQUE INDEX deputynumber_idx ON countverification.filtered_deps ("Deputy No");
-
-CREATE UNIQUE INDEX filteredorder_orderno_idx ON countverification.filtered_orders ("Order No");
-CREATE INDEX filteredorder_case_idx ON countverification.filtered_orders ("Case");
+CREATE UNIQUE INDEX filtereddeps_deputynumber_idx ON countverification.filtered_deps ("Deputy No");
 
 -- persons
 UPDATE countverification.counts SET casrec_source =
@@ -254,6 +251,7 @@ WHERE supervision_table = 'person_warning';
 
 DROP INDEX countverification.filteredorder_orderno_idx;
 DROP INDEX countverification.filteredorder_case_idx;
+DROP INDEX countverification.filtereddeps_deputynumber_idx;
 DROP TABLE countverification.filtered_orders;
 DROP TABLE countverification.filtered_deps;
 

--- a/migration_steps/prepare/counts_verification/sql/count_existing_pc1.sql
+++ b/migration_steps/prepare/counts_verification/sql/count_existing_pc1.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS countverification.counts (
     cp1existing int
 );
 
+-- persons
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT 'persons' AS supervision_table,
 (
@@ -29,36 +30,44 @@ SELECT 'persons' AS supervision_table,
     SELECT COUNT(*) FROM countverification.deputies
 ) AS cp1existing;
 
+-- cases
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT 'cases' AS supervision_table, COUNT(*) AS cp1existing
 FROM countverification.cases;
 
+-- phonenumbers
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'phonenumbers' AS supervision_table,
 (
+    -- client
     SELECT COUNT(*)
     FROM phonenumbers pn
     INNER JOIN countverification.clients cli ON cli.id = pn.person_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM phonenumbers pn
     INNER JOIN countverification.deputies dep ON dep.id = pn.person_id
 ) AS cp1existing;
 
+-- addresses
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'addresses' AS supervision_table,
 (
+    -- client
     SELECT COUNT(*)
     FROM addresses ad
     INNER JOIN countverification.clients cli ON cli.id = ad.person_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM addresses ad
     INNER JOIN countverification.deputies dep ON dep.id = ad.person_id
 ) AS cp1existing;
 
+-- supervision_notes
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'supervision_notes' AS supervision_table,
@@ -72,6 +81,7 @@ SELECT
     INNER JOIN countverification.deputies dep ON dep.id = sn.person_id
 ) AS cp1existing;
 
+-- tasks
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'tasks' AS supervision_table,
@@ -80,97 +90,89 @@ SELECT
     FROM tasks t
     INNER JOIN person_task pt ON pt.task_id = t.id
     INNER JOIN countverification.clients cli on cli.id = pt.person_id
-)+(
-    SELECT COUNT(*)
-    FROM tasks t
-    INNER JOIN person_task pt ON pt.task_id = t.id
-    INNER JOIN countverification.deputies dep on dep.id = pt.person_id
 ) AS cp1existing;
 
+-- death_notifications
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'death_notifications' AS supervision_table,
 (
+    -- client
     SELECT COUNT(*)
     FROM death_notifications dn
     INNER JOIN countverification.clients cli on cli.id = dn.person_id
 )+(
+    -- dpeuty
     SELECT COUNT(*)
     FROM death_notifications dn
     INNER JOIN countverification.deputies dep on dep.id = dn.person_id
 ) AS cp1existing;
 
+-- warnings
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'warnings' AS supervision_table,
 (
+    --client
     SELECT COUNT(*)
     FROM warnings w
     INNER JOIN person_warning pw on pw.warning_id = w.id
     INNER JOIN countverification.clients cli on cli.id = pw.person_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM warnings w
     INNER JOIN person_warning pw on pw.warning_id = w.id
     INNER JOIN countverification.deputies dep on dep.id = pw.person_id
 ) AS cp1existing;
 
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'powerofattorney_person' AS supervision_table,
-(
-    SELECT COUNT(*)
-    FROM powerofattorney_person poa
-    INNER JOIN countverification.clients cli on cli.id = poa.person_id
-)+(
-    SELECT COUNT(*)
-    FROM powerofattorney_person poa
-    INNER JOIN countverification.deputies dep on dep.id = poa.person_id
-) AS cp1existing;
-
+-- annual_report_logs
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'annual_report_logs' AS supervision_table,
 (
+    -- client
     SELECT COUNT(*)
     FROM annual_report_logs al
     INNER JOIN countverification.clients cli ON cli.id = al.client_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM annual_report_logs al
     INNER JOIN countverification.cases ON cases.id = al.order_id
 ) AS cp1existing;
 
+-- visits
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT 'visits' AS supervision_table, COUNT(*) AS cp1existing
 FROM visits v
 LEFT JOIN countverification.clients cli ON cli.id = v.client_id;
 
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'order_deputy' AS supervision_table, COUNT(*) AS cp1existing
-FROM order_deputy od
-INNER JOIN countverification.cases ON cases.id = od.order_id;
-
+-- bonds
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT 'bonds' AS supervision_table, COUNT(*) AS cp1existing
 FROM bonds bon
 INNER JOIN countverification.cases ON cases.id = bon.order_id;
 
+-- feepayer_id
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT 'feepayer_id' AS supervision_table, COUNT(*) AS cp1existing
 FROM persons cli
 WHERE cli.type = 'actor_client' AND cli.caseactorgroup = 'CLIENT-PILOT-ONE'
 AND cli.feepayer_id IS NOT NULL;
 
+-- timeline_event
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'timeline_event' AS supervision_table,
 (
+    -- client
     SELECT COUNT(*)
     FROM timeline_event te
     INNER JOIN person_timeline pt on pt.timelineevent_id = te.id
     INNER JOIN countverification.clients cli on cli.id = pt.person_id
 )+(
+    -- dpeuty
     SELECT COUNT(*)
     FROM timeline_event te
     INNER JOIN person_timeline pt on pt.timelineevent_id = te.id
@@ -178,12 +180,19 @@ SELECT
 ) AS cp1existing;
 
 -- not sure how much value these person_x add
+-- order_deputy
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'order_deputy' AS supervision_table, COUNT(*) AS cp1existing
+FROM order_deputy od
+INNER JOIN countverification.cases ON cases.id = od.order_id;
 
+-- person_caseitem
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT 'person_caseitem' AS supervision_table, COUNT(*) AS cp1existing
 FROM person_caseitem pci
 INNER JOIN countverification.clients cli on cli.id = pci.person_id;
 
+-- person_warning
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'person_warning' AS supervision_table,
@@ -197,19 +206,23 @@ SELECT
     INNER JOIN countverification.deputies dep on dep.id = pw.person_id
 ) AS cp1existing;
 
+-- person_task
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'person_task' AS supervision_table,
 (
+    -- client
     SELECT COUNT(*)
     FROM person_task pt
     INNER JOIN countverification.clients cli on cli.id = pt.person_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM person_task pt
     INNER JOIN countverification.deputies dep on dep.id = pt.person_id
 ) AS cp1existing;
 
+-- person_timeline
 INSERT INTO countverification.counts (supervision_table, cp1existing)
 SELECT
 'person_timeline' AS supervision_table,

--- a/migration_steps/prepare/counts_verification/sql/count_existing_pc1.sql
+++ b/migration_steps/prepare/counts_verification/sql/count_existing_pc1.sql
@@ -1,0 +1,228 @@
+DROP SCHEMA IF EXISTS countverification CASCADE;
+CREATE SCHEMA countverification;
+
+CREATE TABLE IF NOT EXISTS countverification.clients (id int);
+INSERT INTO countverification.clients (id)
+SELECT id FROM persons p WHERE p.type = 'actor_client' AND p.caseactorgroup = 'CLIENT-PILOT-ONE';
+
+CREATE TABLE IF NOT EXISTS countverification.cases (id int);
+INSERT INTO countverification.cases (id)
+SELECT cases.id FROM countverification.clients INNER JOIN cases ON cases.client_id = clients.id;
+
+CREATE TABLE IF NOT EXISTS countverification.deputies (id int);
+INSERT INTO countverification.deputies (id)
+SELECT dep.id
+FROM countverification.cases
+    INNER JOIN order_deputy od ON od.order_id = cases.id
+    INNER JOIN persons dep ON dep.id = od.deputy_id;
+
+CREATE TABLE IF NOT EXISTS countverification.counts (
+    supervision_table varchar(100),
+    cp1existing int
+);
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'persons' AS supervision_table,
+(
+    SELECT COUNT(*) FROM countverification.clients
+)+(
+    SELECT COUNT(*) FROM countverification.deputies
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'cases' AS supervision_table, COUNT(*) AS cp1existing
+FROM countverification.cases;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'phonenumbers' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM phonenumbers pn
+    INNER JOIN countverification.clients cli ON cli.id = pn.person_id
+)+(
+    SELECT COUNT(*)
+    FROM phonenumbers pn
+    INNER JOIN countverification.deputies dep ON dep.id = pn.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'addresses' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM addresses ad
+    INNER JOIN countverification.clients cli ON cli.id = ad.person_id
+)+(
+    SELECT COUNT(*)
+    FROM addresses ad
+    INNER JOIN countverification.deputies dep ON dep.id = ad.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'supervision_notes' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM supervision_notes sn
+    INNER JOIN countverification.clients cli ON cli.id = sn.person_id
+)+(
+    SELECT COUNT(*)
+    FROM supervision_notes sn
+    INNER JOIN countverification.deputies dep ON dep.id = sn.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'tasks' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM tasks t
+    INNER JOIN person_task pt ON pt.task_id = t.id
+    INNER JOIN countverification.clients cli on cli.id = pt.person_id
+)+(
+    SELECT COUNT(*)
+    FROM tasks t
+    INNER JOIN person_task pt ON pt.task_id = t.id
+    INNER JOIN countverification.deputies dep on dep.id = pt.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'death_notifications' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM death_notifications dn
+    INNER JOIN countverification.clients cli on cli.id = dn.person_id
+)+(
+    SELECT COUNT(*)
+    FROM death_notifications dn
+    INNER JOIN countverification.deputies dep on dep.id = dn.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'warnings' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM warnings w
+    INNER JOIN person_warning pw on pw.warning_id = w.id
+    INNER JOIN countverification.clients cli on cli.id = pw.person_id
+)+(
+    SELECT COUNT(*)
+    FROM warnings w
+    INNER JOIN person_warning pw on pw.warning_id = w.id
+    INNER JOIN countverification.deputies dep on dep.id = pw.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'powerofattorney_person' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM powerofattorney_person poa
+    INNER JOIN countverification.clients cli on cli.id = poa.person_id
+)+(
+    SELECT COUNT(*)
+    FROM powerofattorney_person poa
+    INNER JOIN countverification.deputies dep on dep.id = poa.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'annual_report_logs' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM annual_report_logs al
+    INNER JOIN countverification.clients cli ON cli.id = al.client_id
+)+(
+    SELECT COUNT(*)
+    FROM annual_report_logs al
+    INNER JOIN countverification.cases ON cases.id = al.order_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'visits' AS supervision_table, COUNT(*) AS cp1existing
+FROM visits v
+LEFT JOIN countverification.clients cli ON cli.id = v.client_id;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'order_deputy' AS supervision_table, COUNT(*) AS cp1existing
+FROM order_deputy od
+INNER JOIN countverification.cases ON cases.id = od.order_id;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'bonds' AS supervision_table, COUNT(*) AS cp1existing
+FROM bonds bon
+INNER JOIN countverification.cases ON cases.id = bon.order_id;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'feepayer_id' AS supervision_table, COUNT(*) AS cp1existing
+FROM persons cli
+WHERE cli.type = 'actor_client' AND cli.caseactorgroup = 'CLIENT-PILOT-ONE'
+AND cli.feepayer_id IS NOT NULL;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'timeline_event' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM timeline_event te
+    INNER JOIN person_timeline pt on pt.timelineevent_id = te.id
+    INNER JOIN countverification.clients cli on cli.id = pt.person_id
+)+(
+    SELECT COUNT(*)
+    FROM timeline_event te
+    INNER JOIN person_timeline pt on pt.timelineevent_id = te.id
+    INNER JOIN countverification.deputies dep on dep.id = pt.person_id
+) AS cp1existing;
+
+-- not sure how much value these person_x add
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT 'person_caseitem' AS supervision_table, COUNT(*) AS cp1existing
+FROM person_caseitem pci
+INNER JOIN countverification.clients cli on cli.id = pci.person_id;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'person_warning' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM person_warning pw
+    INNER JOIN countverification.clients cli on cli.id = pw.person_id
+)+(
+    SELECT COUNT(*)
+    FROM person_warning pw
+    INNER JOIN countverification.deputies dep on dep.id = pw.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'person_task' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM person_task pt
+    INNER JOIN countverification.clients cli on cli.id = pt.person_id
+)+(
+    SELECT COUNT(*)
+    FROM person_task pt
+    INNER JOIN countverification.deputies dep on dep.id = pt.person_id
+) AS cp1existing;
+
+INSERT INTO countverification.counts (supervision_table, cp1existing)
+SELECT
+'person_timeline' AS supervision_table,
+(
+    SELECT COUNT(*)
+    FROM person_timeline pt
+    INNER JOIN countverification.clients cli on cli.id = pt.person_id
+)+(
+    SELECT COUNT(*)
+    FROM person_timeline pt
+    INNER JOIN countverification.deputies dep on dep.id = pt.person_id
+) AS cp1existing;
+
+DROP TABLE countverification.clients;
+DROP TABLE countverification.cases;
+DROP TABLE countverification.deputies;

--- a/migration_steps/prepare/counts_verification/sql/count_final.sql
+++ b/migration_steps/prepare/counts_verification/sql/count_final.sql
@@ -1,5 +1,11 @@
-DROP SCHEMA IF EXISTS countverification CASCADE;
-CREATE SCHEMA countverification;
+CREATE SCHEMA IF NOT EXISTS countverification;
+CREATE TABLE IF NOT EXISTS countverification.counts (
+    supervision_table varchar(100),
+    cp1existing int,
+    casrec_source int,
+    expected int
+);
+ALTER TABLE countverification.counts ADD IF NOT EXISTS final_count int;
 
 CREATE TABLE IF NOT EXISTS countverification.clients (id int);
 INSERT INTO countverification.clients (id)
@@ -19,29 +25,25 @@ FROM countverification.cases
     INNER JOIN persons dep ON dep.id = od.deputy_id;
 CREATE UNIQUE INDEX cp1deputies_idx ON countverification.deputies (id);
 
-CREATE TABLE IF NOT EXISTS countverification.counts (
-    supervision_table varchar(100),
-    cp1existing int
-);
 
 -- persons
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'persons' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     SELECT COUNT(*) FROM countverification.clients
 )+(
     SELECT COUNT(*) FROM countverification.deputies
-) AS cp1existing;
+)
+WHERE supervision_table = 'persons';
 
 -- cases
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'cases' AS supervision_table, COUNT(*) AS cp1existing
-FROM countverification.cases;
+UPDATE countverification.counts SET final_count =
+(
+    SELECT COUNT(*) FROM countverification.cases
+)
+WHERE supervision_table = 'cases';
 
 -- phonenumbers
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'phonenumbers' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     -- client
     SELECT COUNT(*)
@@ -52,12 +54,11 @@ SELECT
     SELECT COUNT(*)
     FROM phonenumbers pn
     INNER JOIN countverification.deputies dep ON dep.id = pn.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'phonenumbers';
 
 -- addresses
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'addresses' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     -- client
     SELECT COUNT(*)
@@ -68,55 +69,53 @@ SELECT
     SELECT COUNT(*)
     FROM addresses ad
     INNER JOIN countverification.deputies dep ON dep.id = ad.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'addresses';
 
 -- supervision_notes
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'supervision_notes' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
+    -- client
     SELECT COUNT(*)
     FROM supervision_notes sn
     INNER JOIN countverification.clients cli ON cli.id = sn.person_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM supervision_notes sn
     INNER JOIN countverification.deputies dep ON dep.id = sn.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'supervision_notes';
 
 -- tasks
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'tasks' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     SELECT COUNT(*)
     FROM tasks t
     INNER JOIN person_task pt ON pt.task_id = t.id
     INNER JOIN countverification.clients cli on cli.id = pt.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'tasks';
 
--- death_notifications
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'death_notifications' AS supervision_table,
+-- death notifications
+UPDATE countverification.counts SET final_count =
 (
     -- client
     SELECT COUNT(*)
     FROM death_notifications dn
     INNER JOIN countverification.clients cli on cli.id = dn.person_id
 )+(
-    -- dpeuty
+    -- deputy
     SELECT COUNT(*)
     FROM death_notifications dn
     INNER JOIN countverification.deputies dep on dep.id = dn.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'death_notifications';
 
 -- warnings
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'warnings' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
-    --client
+    -- client
     SELECT COUNT(*)
     FROM warnings w
     INNER JOIN person_warning pw on pw.warning_id = w.id
@@ -127,12 +126,11 @@ SELECT
     FROM warnings w
     INNER JOIN person_warning pw on pw.warning_id = w.id
     INNER JOIN countverification.deputies dep on dep.id = pw.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'warnings';
 
 -- annual_report_logs
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'annual_report_logs' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     -- client
     SELECT COUNT(*)
@@ -143,31 +141,39 @@ SELECT
     SELECT COUNT(*)
     FROM annual_report_logs al
     INNER JOIN countverification.cases ON cases.id = al.order_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'annual_report_logs';
 
 -- visits
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'visits' AS supervision_table, COUNT(*) AS cp1existing
-FROM visits v
-LEFT JOIN countverification.clients cli ON cli.id = v.client_id;
+UPDATE countverification.counts SET final_count =
+(
+    SELECT COUNT(*)
+    FROM visits v
+    LEFT JOIN countverification.clients cli ON cli.id = v.client_id
+)
+WHERE supervision_table = 'visits';
 
 -- bonds
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'bonds' AS supervision_table, COUNT(*) AS cp1existing
-FROM bonds bon
-INNER JOIN countverification.cases ON cases.id = bon.order_id;
+UPDATE countverification.counts SET final_count =
+(
+    SELECT COUNT(*)
+    FROM bonds bon
+    INNER JOIN countverification.cases ON cases.id = bon.order_id
+)
+WHERE supervision_table = 'bonds';
 
 -- feepayer_id
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'feepayer_id' AS supervision_table, COUNT(*) AS cp1existing
-FROM persons cli
-WHERE cli.type = 'actor_client' AND cli.caseactorgroup = 'CLIENT-PILOT-ONE'
-AND cli.feepayer_id IS NOT NULL;
+UPDATE countverification.counts SET final_count =
+(
+    SELECT COUNT(*)
+    FROM persons cli
+    WHERE cli.type = 'actor_client' AND cli.caseactorgroup = 'CLIENT-PILOT-ONE'
+    AND cli.feepayer_id IS NOT NULL
+)
+WHERE supervision_table = 'feepayer_id';
 
 -- timeline_event
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'timeline_event' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     -- client
     SELECT COUNT(*)
@@ -180,39 +186,46 @@ SELECT
     FROM timeline_event te
     INNER JOIN person_timeline pt on pt.timelineevent_id = te.id
     INNER JOIN countverification.deputies dep on dep.id = pt.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'timeline_event';
 
 -- not sure how much value these person_x add
+
 -- order_deputy
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'order_deputy' AS supervision_table, COUNT(*) AS cp1existing
-FROM order_deputy od
-INNER JOIN countverification.cases ON cases.id = od.order_id;
+UPDATE countverification.counts SET final_count =
+(
+    SELECT COUNT(*)
+    FROM order_deputy od
+    INNER JOIN countverification.cases ON cases.id = od.order_id
+)
+WHERE supervision_table = 'order_deputy';
 
 -- person_caseitem
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT 'person_caseitem' AS supervision_table, COUNT(*) AS cp1existing
-FROM person_caseitem pci
-INNER JOIN countverification.clients cli on cli.id = pci.person_id;
+UPDATE countverification.counts SET final_count =
+(
+    SELECT COUNT(*)
+    FROM person_caseitem pci
+    INNER JOIN countverification.clients cli on cli.id = pci.person_id
+)
+WHERE supervision_table = 'person_caseitem';
 
 -- person_warning
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'person_warning' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
+    -- client
     SELECT COUNT(*)
     FROM person_warning pw
     INNER JOIN countverification.clients cli on cli.id = pw.person_id
 )+(
+    -- deputy
     SELECT COUNT(*)
     FROM person_warning pw
     INNER JOIN countverification.deputies dep on dep.id = pw.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'person_warning';
 
 -- person_task
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'person_task' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     -- client
     SELECT COUNT(*)
@@ -223,12 +236,11 @@ SELECT
     SELECT COUNT(*)
     FROM person_task pt
     INNER JOIN countverification.deputies dep on dep.id = pt.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'person_task';
 
 -- person_timeline
-INSERT INTO countverification.counts (supervision_table, cp1existing)
-SELECT
-'person_timeline' AS supervision_table,
+UPDATE countverification.counts SET final_count =
 (
     SELECT COUNT(*)
     FROM person_timeline pt
@@ -237,7 +249,9 @@ SELECT
     SELECT COUNT(*)
     FROM person_timeline pt
     INNER JOIN countverification.deputies dep on dep.id = pt.person_id
-) AS cp1existing;
+)
+WHERE supervision_table = 'person_timeline';
+
 
 DROP INDEX countverification.cp1clients_idx;
 DROP INDEX countverification.cp1cases_idx;
@@ -246,3 +260,6 @@ DROP INDEX countverification.cp1deputies_idx;
 DROP TABLE countverification.clients;
 DROP TABLE countverification.cases;
 DROP TABLE countverification.deputies;
+
+ALTER TABLE countverification.counts ADD result varchar(10);
+UPDATE countverification.counts SET result = CASE WHEN final_count=expected THEN 'OK' ELSE 'ERROR' END;

--- a/migration_steps/prepare/prepare.sh
+++ b/migration_steps/prepare/prepare.sh
@@ -24,6 +24,8 @@ else
   echo "delete_existing_data should not run on ${ENVIRONMENT}"
 fi
 
+python3 "${DIR}/counts_verification/count_existing_pc1.py"
+
 python3 "${DIR}/prepare_source/app/app.py" --preserve_schemas="${SCHEMAS}"
 python3 "${DIR}/create_stage_schema/app/app.py"
 


### PR DESCRIPTION
## Purpose

To provide at-a-glance indication that the counts of migrated rows match exactly what we expect

To disambiguate on any discrepancies caused by CLIENT-PILOT-ONE existing data

The automated DB validation only proves that source rows from Casrec are to be found in Sirius after migration. But Sirius could contain MORE data than source, and we needed a way to monitor this.

This is expected, to the extent that Sirius is source-of-truth for any entity relating to a client with a caseactorgroup of "CLIENT-PILOT-ONE"

There should not be any further data on Sirius. If there is, it's a sign that either:
1. The 'Delete script' which runs before migration is not deleting some data that it should, or
2. That we are migrating too much data

In the case of 2, one possible explanation is that we're not removing data pertaining to cases WHERE "Ord Stat" != 'Open'


## Approach

Take a snapshot of data counts at three points:
1. Count the data on Sirius, just after the DELETE script, where Sirius should now only contain CP1 data
2. Count the source Casrec data just after the corref filtering has taken place
3. Count the data on Sirius, after the migration

Print results out within log output


## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
