### PR TITLE
Fix client_nodebtchase_warnings validation.

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -210,7 +210,7 @@
             "joins": [],
             "exception_table_join": "LEFT JOIN casrec_csv.exceptions_client_nodebtchase_warnings exc_table ON exc_table.caserecnumber = pat.\"Case\"",
             "where_clauses": [
-                "casrec_csv.pat.\"Debt chase\" != ''"
+                "casrec_csv.pat.\"Debt chase\" = '1'"
             ]
         },
         "sirius": {


### PR DESCRIPTION
## Purpose

Fix client_nodebtchase_warnings validation.

## Approach

Set explicit condition for "Debt chase" = 1 to capture any errors in future in case more values get added in Casrec

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
