### PR TITLE
IN-1100 reporttype assignment

### DIFF
--- a/migration_steps/transform_casrec/transform/transform_tests/transform_data_tests/entities/reporting/test_annual_report_type_assignments.py
+++ b/migration_steps/transform_casrec/transform/transform_tests/transform_data_tests/entities/reporting/test_annual_report_type_assignments.py
@@ -23,6 +23,31 @@ def test_calculate_report_types_one_case_multiple_orders():
     assert_frame_equal(expected_df, transformed_df)
 
 
+def test_calculate_report_types_one_case_multiple_report_logs_with_same_end_date():
+    """
+    There was a bug where, if an annual_report_log related to two orders with
+    the same end date, but the first row had a "Closed" status, the "Active"
+    row after it was ignored. The ordering of the ord_stat values is important
+    in this test: two rows have the same end date, but the row with "Closed"
+    Ord Stat comes before the row which is "Active".
+    """
+    test_df = pd.DataFrame(
+        {
+            "annualreport_id": [50, 50, 50, 50],
+            "end_date": ["2018-01-01", "2019-01-01", "2020-01-01", "2020-01-01"],
+            "sirius_report_log_casrec_case_no": ["C1", "C1", "C1", "C1"],
+            "ord_stat": ["Closed", "Active", "Closed", "Active"],
+            "ord_risk_lvl": ["3", "3", "3", "3"],
+        }
+    )
+
+    expected_df = pd.DataFrame({"annualreport_id": [50], "reporttype": ["OPG103"]})
+
+    transformed_df = calculate_report_types(test_df)
+
+    assert_frame_equal(expected_df, transformed_df)
+
+
 def test_calculate_report_types_multiple_reports_same_case():
     test_df = pd.DataFrame(
         {


### PR DESCRIPTION
## Purpose

[IN-1100](https://opgtransform.atlassian.net/browse/IN-1100)

## Approach

Fix bug in my code which assigned reporttype using incorrect casrec order.

## Learning

If there are two rows like so in a dataframe:

```
| 0 |                 1 | 2001-01-26 00:00:00 |                           10000037 | Closed     |              2 |               10000037 |
| 1 |                 1 | 2001-01-26 00:00:00 |                           10000037 | Active     |              2 |               10000037 |
```

...and you use idxmax() to get the ID of the row with the largest date value (third column here), you get the first row containing the largest value (row 0), not the second row (row 1).

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [X] I have added relevant logging with appropriate levels to my code
* [X] I have updated documentation where relevant
* [X] I have added tests to prove my work
* [ ] The product team have tested these changes
