### PR TITLE
IN-1046 Convert Remarks timestamps to UTC

### DIFF
--- a/migration_steps/shared/sql/transformation_functions.sql
+++ b/migration_steps/shared/sql/transformation_functions.sql
@@ -79,7 +79,7 @@ BEGIN
 
     TimeVal = TimeVal::time::varchar;
 
-    RETURN CONCAT(DateVal, ' ', TimeVal)::timestamp;
+    RETURN CONCAT(DateVal, ' ', TimeVal)::timestamp AT TIME ZONE 'Europe/London' AT TIME ZONE 'UTC';
 END;
 $$ LANGUAGE plpgsql;
 

--- a/migration_steps/transform_casrec/transform/app/utilities/standard_transformations.py
+++ b/migration_steps/transform_casrec/transform/app/utilities/standard_transformations.py
@@ -299,6 +299,7 @@ def convert_to_timestamp(
         axis=1,
     )
     df[result_col] = df[result_col].astype("datetime64[ns]")
+    df[result_col] = df[result_col].dt.tz_localize('Europe/London').dt.tz_convert('UTC')
 
     df = df.drop(columns=original_cols)
 

--- a/migration_steps/transform_casrec/transform/transform_tests/utilities_tests/standard_transformations/convert_to_timestamp/test_convert_to_timestamp.py
+++ b/migration_steps/transform_casrec/transform/transform_tests/utilities_tests/standard_transformations/convert_to_timestamp/test_convert_to_timestamp.py
@@ -12,6 +12,7 @@ def test_convert_to_timestamp():
             "2020-06-14",
             "",
             "NaT",
+            "2020-12-01",
         ],
         "time_col": [
             "",
@@ -19,6 +20,7 @@ def test_convert_to_timestamp():
             "08:54:04.032000",
             "09:54:04.032000",
             "10:54:04.032000",
+            "07:00:00.032000",
         ],
     }
 
@@ -26,16 +28,17 @@ def test_convert_to_timestamp():
 
     expected_data = {
         "datetime_col": [
-            "2020-06-12 00:00:00",
-            "2020-06-13 00:00:00",
-            "2020-06-14 08:54:04",
+            "2020-06-11 23:00:00",
+            "2020-06-12 23:00:00",
+            "2020-06-14 07:54:04",
             None,
             None,
+            "2020-12-01 07:00:00"
         ],
     }
 
     expected_data_df = pd.DataFrame(expected_data, columns=[x for x in expected_data])
-    expected_data_df["datetime_col"] = pd.to_datetime(expected_data["datetime_col"], dayfirst=True)
+    expected_data_df["datetime_col"] = pd.to_datetime(expected_data["datetime_col"], dayfirst=True, utc=True)
 
     result_df = convert_to_timestamp(
         original_cols=["date_col", "time_col"],


### PR DESCRIPTION
## Purpose

https://opgtransform.atlassian.net/browse/IN-1046

## Approach

Assuming that datetimes in source are GMT/BST, convert them to UTC for remarks.

Remarks is currently the only entity that uses the `convert_to_timestamp` transformation.

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
