### PR TITLE
IN-1130b cut down dependabot flow further

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
         - matches: {pattern: "^dependabot/.+$", value: << pipeline.git.branch >>}
         - << pipeline.parameters.run_main >>
     jobs:
-      - build:
+      - build_short:
           name: build and unit tests dependabot
       - job_complete:
           name: job complete notification
@@ -750,10 +750,18 @@ orbs:
                   then echo "export CI_PULL_REQUEST=\"${CIRCLE_BUILD_URL}\"" >> $BASH_ENV
                 fi
 
-                ENTITIES=$(cat ENTITIES)
+                if [ -f ENTITIES ]; then
+                    ENTITIES=$(cat ENTITIES)
+                else
+                    ENTITIES="None"
+                fi
                 echo "export ENTITIES=\"${ENTITIES}\"" >> $BASH_ENV
 
-                ENVIRONMENT_TITLE=$(cat ENVIRONMENT_TITLE)
+                if [ -f ENVIRONMENT_TITLE ]; then
+                    ENVIRONMENT_TITLE=$(cat ENVIRONMENT_TITLE)
+                else
+                    ENVIRONMENT_TITLE="Development"
+                fi
                 echo "export ENVIRONMENT_TITLE=\"${ENVIRONMENT_TITLE}\"" >> $BASH_ENV
               working_directory: ~/project
       notify_if_success:
@@ -1246,6 +1254,39 @@ jobs:
       - notififications/notify_env_vars
       - notififications/notify_if_fail
 
+  build_short:
+    executor: migration/python
+    resource_class: small
+    environment:
+      AWS_REGION: eu-west-1
+      AWS_CONFIG_FILE: ~/project/aws_config
+      AWS_REGISTRY: 311462405659.dkr.ecr.eu-west-1.amazonaws.com
+    steps:
+      - dockerhub_helper/dockerhub_login
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Export version as latest
+          command: echo "export VERSION=latest" >> $BASH_ENV
+      - run:
+          name: Switch out docker-compose.override file
+          command: |
+            echo "Switching override so we do not use volume mounts"
+            rm docker-compose.override.yml
+            mv docker-compose.override.ci.yml docker-compose.override.yml
+      - run:
+          name: Build base image
+          command: docker build base_image -t opg_casrec_migration_base_image:latest
+      - run:
+          name: Build images
+          command: docker-compose -f docker-compose.ci.yml build --parallel
+      - run:
+          name: Run unit tests
+          command: docker-compose up unit_tests
+      - run:
+          name: Full local migration run through
+          command: ./migrate.sh
+
   build:
     executor: migration/python
     resource_class: small
@@ -1281,21 +1322,6 @@ jobs:
       - run:
           name: Show version
           command: echo ${VERSION}
-      - run:
-          name: Install python requirements
-          command: |
-            pip3 install -r base_image/requirements.txt
-            pip3 install -r migration_steps/shared/shared_tests/requirements.txt
-      - run:
-          name: Run transform_casrec unit tests
-          command: |
-            export PYTHONPATH=~/project/migration_steps/transform_casrec:~/project/migration_steps/transform_casrec/transform/app
-            python3 -m pytest migration_steps/transform_casrec/transform/transform_tests --cov-fail-under=85
-      - run:
-          name: Run shared utilities unit tests
-          command: |
-            export PYTHONPATH=~/project/migration_steps/shared:~/project/migration_steps/shared/shared_tests
-            python3 -m pytest migration_steps/shared/shared_tests
       - when:
           condition: << parameters.push_mappings >>
           steps:
@@ -1313,13 +1339,17 @@ jobs:
           name: Build images
           command: docker-compose -f docker-compose.ci.yml build --parallel
       - run:
-          name: Full local run through
+          name: Switch out docker-compose.override file
           command: |
             echo "Switching override so we do not use volume mounts"
             rm docker-compose.override.yml
             mv docker-compose.override.ci.yml docker-compose.override.yml
-            echo "Running migrate.sh"
-            ./migrate.sh
+      - run:
+          name: Run unit tests
+          command: docker-compose up unit_tests
+      - run:
+          name: Full local migration run through
+          command: ./migrate.sh
       - run:
           name: Push images
           command: docker-compose -f docker-compose.ci.yml push

--- a/base_image/requirements.txt
+++ b/base_image/requirements.txt
@@ -24,9 +24,6 @@ python-json-logger==2.0.1
 colorama==0.4.4
 tabulate~=0.8
 config~=0.5
-pytest==6.1.2
-pytest_cases==2.7.2
-pytest-cov==2.10.1
 psutil==5.8.0
 faker
 py-moneyed

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -62,3 +62,9 @@ services:
       - ./migration_steps/validation/functional_api_tests.sh:/validation/functional_api_tests.sh
       - ./migration_steps/validation/light_touch_api_tests.sh:/validation/light_touch_api_tests.sh
       - ./migration_steps/shared:/shared
+
+  unit_tests:
+    volumes:
+      - ./migration_steps/unit-test.sh:/unit-test.sh
+      - ./migration_steps/transform_casrec:/transform_casrec
+      - ./migration_steps/shared:/shared

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,3 +175,9 @@ services:
       SIRIUS_DB_PORT: 5432
       ENVIRONMENT: local
     depends_on: [casrec_db, postgres-sirius]
+  unit_tests:
+    build:
+      context: ./migration_steps
+      dockerfile: unit-tests-dockerfile
+    environment:
+      ENVIRONMENT: local

--- a/migration_steps/shared/shared_tests/requirements.txt
+++ b/migration_steps/shared/shared_tests/requirements.txt
@@ -1,5 +1,3 @@
-sh~=1.14
-pandas~=1.1
 pytest==6.1.2
 pytest_cases==2.7.2
 pytest-cov==2.10.1

--- a/migration_steps/unit-tests-dockerfile
+++ b/migration_steps/unit-tests-dockerfile
@@ -1,0 +1,8 @@
+FROM opg_casrec_migration_base_image:latest
+COPY transform_casrec migration_steps/transform_casrec
+COPY shared migration_steps/shared
+COPY unit-tests.sh unit-tests.sh
+RUN chmod +x unit-tests.sh
+RUN pip3 install -r migration_steps/shared/shared_tests/requirements.txt
+ENV PYTHONPATH=migration_steps/transform_casrec/transform/transform_tests:migration_steps/transform_casrec/transform/app:migration_steps/transform_casrec/transform:migration_steps/shared:migration_steps/shared/shared_tests
+CMD ["./unit-tests.sh"]

--- a/migration_steps/unit-tests.sh
+++ b/migration_steps/unit-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Running tranform unit tests - "
+python3 -m pytest migration_steps/transform_casrec/transform/transform_tests --cov-fail-under=85
+echo "Running shared unit tests - "
+python3 -m pytest migration_steps/shared/shared_tests


### PR DESCRIPTION
## Purpose

Dependabot flow was still janky and we don't need to be pushing images here as it gets done after merge. This makes it smooth sailing.

Also moved the tests into containers as that seemed more secure than installing dependencies directly onto circle which has numerous env vars

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
