### PR TITLE
fix deputycol as int64 and minor ci improvement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ workflows:
       - tag_image_for_environment:
           name: tag image for qa
           environment_tag: qa
+          previous_tag: main
           requires: [migration - response api tests preproduction]
       - approve:
           name: approve qa kick off
@@ -431,6 +432,7 @@ workflows:
       - tag_image_for_environment:
           name: tag image for production
           environment_tag: production
+          previous_tag: qa
           requires: [migration - validation qa]
       - run_elasticsearch_reset:
           name: full reindex elasticsearch qa
@@ -1025,11 +1027,16 @@ jobs:
         description: environment tag for where image can be used
         type: string
         default: "development"
+      previous_tag:
+        description: environment tag for where image can be used
+        type: string
+        default: "development"
     environment:
       AWS_REGION: eu-west-1
       AWS_CONFIG_FILE: ~/project/aws_config
       AWS_REGISTRY: 311462405659.dkr.ecr.eu-west-1.amazonaws.com
       ENVIRONMENT_TAG: << parameters.environment_tag >>
+      PREVIOUS_TAG: << parameters.previous_tag >>
     working_directory: ~/project
     steps:
       - checkout
@@ -1056,7 +1063,7 @@ jobs:
       - run:
           name: Retag images
           command: |
-            for i in `docker image ls | grep main- | awk '{print $1":"$2}'`
+            for i in `docker image ls | grep "${PREVIOUS_TAG}-" | awk '{print $1":"$2}'`
             do
               docker tag $i `echo $i | awk '-F:' '{print $1":"}'`${NEW_TAG}
             done
@@ -1325,6 +1332,9 @@ jobs:
       - when:
           condition: << parameters.push_mappings >>
           steps:
+            - run:
+                name: Install requirements
+                command: pip install boto3 click
             - run:
                 name: zip and upload mappings zip file
                 command: python3 upload_mappings.py --role migrations-ci

--- a/docker-compose.sirius.yml
+++ b/docker-compose.sirius.yml
@@ -141,3 +141,9 @@ services:
       SIRIUS_DB_PORT: 5432
       ENVIRONMENT: local
     depends_on: [casrec_db]
+  unit_tests:
+    build:
+      context: ./migration_steps
+      dockerfile: unit-tests-dockerfile
+    environment:
+      ENVIRONMENT: local

--- a/migration_steps/load_to_sirius/move_data/utilities.py
+++ b/migration_steps/load_to_sirius/move_data/utilities.py
@@ -35,6 +35,8 @@ def handle_special_cases(table_name, df):
         df["risk_score"] = df["risk_score"].astype("Int64")
         log.debug("Reformat 'feepayer_id' to nullable int")
         df["feepayer_id"] = df["feepayer_id"].astype("Int64")
+        log.debug("Reformat 'deputycasrecid' to nullable int")
+        df["deputycasrecid"] = df["deputycasrecid"].astype("Int64")
     if table_name == "finance_invoice":
         log.debug("Reformat 'finance_person_id' to nullable int")
         df["finance_person_id"] = df["finance_person_id"].astype("Int64")


### PR DESCRIPTION
I've smooshed together 4 little bug fixes here for simplicity in getting it through CI.

They are:
- This mornings fail on preprod is because of pandas doing that annpoying thing with int conversion so fixing deputycasrecid as int64 on load.
- tag of prod image never worked so made that dynamic
- I'd broken push mappings that happens only on merge of pr when i containerised all the unit tests. Adding the dependencies just for that back in.
- unittests needs to be in the sirius docker-compose file as it's in the override file