### PR TITLE
IN-1135 fix address count

### DIFF
--- a/migration_steps/prepare_source_data/counts_verification/sql/count_casrec_source.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/count_casrec_source.sql
@@ -96,7 +96,9 @@ UPDATE countverification.counts SET {working_column} =
 )+(
     -- deputy
    SELECT COUNT(*) FROM (
-        SELECT DISTINCT d."Email", d."Dep Surname", d."Dep Forename", add."Dep Postcode"
+        SELECT DISTINCT LOWER(TRIM(COALESCE(d."Email", ''))),
+        LOWER(TRIM(COALESCE(d."Dep Surname", ''))),
+        LOWER(TRIM(COALESCE(add."Dep Postcode", '')))
         FROM casrec_csv.deputy_address add
         INNER JOIN casrec_csv.deputyship ds
             ON ds."Dep Addr No" = add."Dep Addr No"


### PR DESCRIPTION
## Purpose

Address counts were further complicated by surname sometimes being an org or sometimes a surname and the fact that some of the previous cp1 postcodes shared the same deputy details and postcodes as new ones. 

This is a limitation of different way they are linked so we can't accurately infer the counts from the casrec data.. or at least i couldn't

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
