### PR TITLE
IN-1147 improve filtered api tests

### DIFF
--- a/migration_steps/validation/api_test_data_s3_upload/app/validation/api_tests/deputy_clients.csv
+++ b/migration_steps/validation/api_test_data_s3_upload/app/validation/api_tests/deputy_clients.csv
@@ -1,17 +1,17 @@
 endpoint,entity_ref,json_locator,test_purpose,api_response
-/api/v1/deputies/{id}/clients,11019897,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_other5,Other Relation
-/api/v1/deputies/{id}/clients,13323382,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_spouse,Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse|Spouse
-/api/v1/deputies/{id}/clients,10202386,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_child,Child of Client
-/api/v1/deputies/{id}/clients,11497854,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_parent,Parent of Client
-/api/v1/deputies/{id}/clients,10200748,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_civil,Civil Partner|Civil Partner|Civil Partner|Civil Partner|Civil Partner|Civil Partner
-/api/v1/deputies/{id}/clients,10084054,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_other19,Other Relation
-/api/v1/deputies/{id}/clients,10152488,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_bank,Bank Official
-/api/v1/deputies/{id}/clients,10020983,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_sol,Solicitor
-/api/v1/deputies/{id}/clients,13567497,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_acc,Accountant
-/api/v1/deputies/{id}/clients,1346927T,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_other_prof,Other Professional|Other Professional|Other Professional|Other Professional|Other Professional|Other Professional|Other Professional|Other Professional
-/api/v1/deputies/{id}/clients,10058508,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_friend,Friend|Friend|Friend|Friend|Friend|Friend|Friend|Friend|Friend|Friend|Friend|Friend
-/api/v1/deputies/{id}/clients,94026637,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_partner,Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)|Partner (Not Civil Partner)
-/api/v1/deputies/{id}/clients,1030841T,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_panel,Panel Deputy|Panel Deputy|Panel Deputy
-/api/v1/deputies/{id}/clients,13578754,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_sibling,Sibling|Sibling|Sibling|Sibling|Sibling|Sibling|Sibling|Sibling|Sibling|Sibling
-/api/v1/deputies/{id}/clients,10192899,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_unreg,Unregulated Pro Deputy|Unregulated Pro Deputy|Unregulated Pro Deputy|Unregulated Pro Deputy|Unregulated Pro Deputy|Unregulated Pro Deputy
-/api/v1/deputies/{id}/clients,13562090,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,relationshipToClient_legal,Legal Professional|Legal Professional
+/api/v1/deputies/{id}/clients,11019897,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_other5,Other Relation
+/api/v1/deputies/{id}/clients,13323382,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_spouse,Spouse
+/api/v1/deputies/{id}/clients,10202386,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_child,Child of Client
+/api/v1/deputies/{id}/clients,11497854,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_parent,Parent of Client
+/api/v1/deputies/{id}/clients,10200748,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_civil,Civil Partner
+/api/v1/deputies/{id}/clients,10084054,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_other19,Other Relation
+/api/v1/deputies/{id}/clients,10152488,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_bank,Bank Official
+/api/v1/deputies/{id}/clients,10020983,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_sol,Solicitor
+/api/v1/deputies/{id}/clients,13567497,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_acc,Accountant
+/api/v1/deputies/{id}/clients,1346927T,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_other_prof,Other Professional
+/api/v1/deputies/{id}/clients,10058508,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_friend,Friend
+/api/v1/deputies/{id}/clients,94026637,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_partner,Partner (Not Civil Partner)
+/api/v1/deputies/{id}/clients,1030841T,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_panel,Panel Deputy
+/api/v1/deputies/{id}/clients,13578754,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_sibling,Sibling
+/api/v1/deputies/{id}/clients,10192899,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_unreg,Unregulated Pro Deputy
+/api/v1/deputies/{id}/clients,13562090,persons.[*].orders.[*].deputies.[*].relationshipToClient.label,includes_relationshipToClient_legal,Legal Professional


### PR DESCRIPTION
## Purpose

Just a quick one to improve two things I noticed when fixing the files for filtered api tests
1. It's not logging when we're filtering out a tested case
2. We have no mechanism to just check if something is in a result set. We often do want to check the full result set but sometimes where it changes a lot and we're only interested if a code appears in the list then we need a check that doesn't check all the responses but just that a certain field appears in the result set brought back.

## Approach

Made the above changes

## Learning

NA
## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
