### PR TITLE
In 1149b

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,69 +46,26 @@ workflows:
         - << pipeline.parameters.run_main >>
     jobs:
       - persist_parameters:
-          name: persist parameters development
-          param_workspace: development
-          environment_title: Development-Branch
-      - manage_workflow:
-          requires: [persist parameters development]
-          name: manage workflow
-      - reset_sirius:
-          name: reset the sirius fixtures development
-          requires: [manage workflow]
-          tf_workspace: development
+          name: persist parameters rehearsal
+          param_workspace: rehearsal
+          environment_title: Rehearsal-Manual
       - build:
           name: build and unit tests
-          requires: [manage workflow, persist parameters development]
-      - infrastructure:
-          name: build shared infra development
+          requires: [persist parameters rehearsal]
+      - run_task:
+          name: migration - load sirius rehearsal
           requires: [build and unit tests]
-          tf_workspace: development
-          tf_command: apply
-          folder: shared
-      - load_casrec_db:
-          name: load casrec db
-          requires: [build shared infra development]
-      - infrastructure:
-          name: plan infra development
-          requires: [build shared infra development]
-          tf_workspace: development
-          tf_command: plan
-      - infrastructure:
-          name: build infra development
-          requires: [plan infra development]
-          tf_workspace: development
-          tf_command: apply
-      - scale-services:
-          name: scale down poller service for migration development
-          requires: [reset the sirius fixtures development]
-          replicas: "0"
-          profile: "migrations-ci-sirius-dev"
-          service: "notify-poller"
-          cluster: "casmigrate"
-      - run_tasks:
-          name: migration - run all tasks development
-          requires: [
-            build infra development,
-            load casrec db,
-            reset the sirius fixtures development,
-            scale down poller service for migration development
-          ]
-          tf_workspace: development
-      - scale-services:
-          name: scale up poller service for migration development
-          requires: [migration - run all tasks development]
-          replicas: "1"
-          profile: "migrations-ci-sirius-dev"
-          service: "notify-poller"
-          cluster: "casmigrate"
-      - run_elasticsearch_reset:
-          name: full reindex elasticsearch development
-          requires: [migration - run all tasks development]
-          tf_workspace: development
+          tf_workspace: rehearsal
+          runner_command: migration-load-sirius
+      - run_task:
+          name: migration - validation rehearsal
+          requires: [migration - load sirius rehearsal]
+          tf_workspace: rehearsal
+          runner_command: migration-validation
       - job_complete:
           name: job complete notification
-          requires: [migration - run all tasks development]
-          workspace: development
+          requires: [migration - validation rehearsal]
+          workspace: rehearsal
 
   main:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,22 @@ parameters:
   run_qa:
     type: boolean
     default: false
-  run_production:
+  run_production_1:
     type: boolean
     default: false
-  run_rehearsal:
+  run_production_2:
+    type: boolean
+    default: false
+  run_production_3:
+    type: boolean
+    default: false
+  run_rehearsal_1:
+    type: boolean
+    default: false
+  run_rehearsal_2:
+    type: boolean
+    default: false
+  run_rehearsal_3:
     type: boolean
     default: false
   override_tag:
@@ -46,26 +58,69 @@ workflows:
         - << pipeline.parameters.run_main >>
     jobs:
       - persist_parameters:
-          name: persist parameters rehearsal
-          param_workspace: rehearsal
-          environment_title: Rehearsal-Manual
+          name: persist parameters development
+          param_workspace: development
+          environment_title: Development-Branch
+      - manage_workflow:
+          requires: [persist parameters development]
+          name: manage workflow
+      - reset_sirius:
+          name: reset the sirius fixtures development
+          requires: [manage workflow]
+          tf_workspace: development
       - build:
           name: build and unit tests
-          requires: [persist parameters rehearsal]
-      - run_task:
-          name: migration - load sirius rehearsal
+          requires: [manage workflow, persist parameters development]
+      - infrastructure:
+          name: build shared infra development
           requires: [build and unit tests]
-          tf_workspace: rehearsal
-          runner_command: migration-load-sirius
-      - run_task:
-          name: migration - validation rehearsal
-          requires: [migration - load sirius rehearsal]
-          tf_workspace: rehearsal
-          runner_command: migration-validation
+          tf_workspace: development
+          tf_command: apply
+          folder: shared
+      - load_casrec_db:
+          name: load casrec db
+          requires: [build shared infra development]
+      - infrastructure:
+          name: plan infra development
+          requires: [build shared infra development]
+          tf_workspace: development
+          tf_command: plan
+      - infrastructure:
+          name: build infra development
+          requires: [plan infra development]
+          tf_workspace: development
+          tf_command: apply
+      - scale-services:
+          name: scale down poller service for migration development
+          requires: [reset the sirius fixtures development]
+          replicas: "0"
+          profile: "migrations-ci-sirius-dev"
+          service: "notify-poller"
+          cluster: "casmigrate"
+      - run_tasks:
+          name: migration - run all tasks development
+          requires: [
+            build infra development,
+            load casrec db,
+            reset the sirius fixtures development,
+            scale down poller service for migration development
+          ]
+          tf_workspace: development
+      - scale-services:
+          name: scale up poller service for migration development
+          requires: [migration - run all tasks development]
+          replicas: "1"
+          profile: "migrations-ci-sirius-dev"
+          service: "notify-poller"
+          cluster: "casmigrate"
+      - run_elasticsearch_reset:
+          name: full reindex elasticsearch development
+          requires: [migration - run all tasks development]
+          tf_workspace: development
       - job_complete:
           name: job complete notification
-          requires: [migration - validation rehearsal]
-          workspace: rehearsal
+          requires: [migration - run all tasks development]
+          workspace: development
 
   main:
     when:
@@ -402,11 +457,11 @@ workflows:
           requires: [migration - validation qa]
           workspace: qa
 
-  production:
+  production_1:
     when:
       and:
         - equal: [main, << pipeline.git.branch >>]
-        - << pipeline.parameters.run_production >>
+        - << pipeline.parameters.run_production_1 >>
     jobs:
       - persist_parameters:
           name: persist parameters production
@@ -426,20 +481,9 @@ workflows:
           requires: [plan infra production]
           tf_workspace: production
           tf_command: apply
-# LEAVE COMMENTED OUT FOR SAFETY PURPOSES BUT HAVE CREATED IDENTICAL TO REHEARSAL
-#      - scale-services:
-#          name: scale down poller service for migration production
-#          requires: [build infra production]
-#          replicas: "0"
-#          profile: "migrations-ci-sirius-production"
-#          service: "notify-poller"
-#          cluster: "production"
 #      - run_task:
 #          name: migration - initialise environments production
-#          requires: [
-#            build infra production,
-#            scale down poller service for migration production
-#         ]
+#          requires: [build infra production]
 #          runner_command: migration-initialise-environments
 #          tf_workspace: production
 #      - run_task:
@@ -462,6 +506,26 @@ workflows:
 #          requires: [migration - transform production]
 #          tf_workspace: production
 #          runner_command: migration-integration
+      - job_complete:
+          name: job complete notification
+#          requires: [migration - integration production]
+          requires: [build infra production]
+          workspace: production
+
+#  production_2:
+#    when:
+#      and:
+#        - equal: [main, << pipeline.git.branch >>]
+#        - << pipeline.parameters.run_production_2 >>
+#    jobs:
+#      - persist_parameters:
+#          name: persist parameters production
+#          param_workspace: production
+#          environment_title: Rehearsal-Manual
+#      - get_latest_image:
+#          name: get latest tag production
+#          requires: [persist parameters production]
+#          image_tag: production
 #      - run_task:
 #          name: migration - load sirius production
 #          requires: [migration - integration production]
@@ -472,38 +536,50 @@ workflows:
 #          requires: [migration - load sirius production]
 #          tf_workspace: production
 #          runner_command: migration-validation
+#      - job_complete:
+#          name: job complete notification
+#          requires: [migration - validation production]
+#          workspace: production
+#
+#
+#  production_3:
+#    when:
+#      and:
+#        - equal: [main, << pipeline.git.branch >>]
+#        - << pipeline.parameters.run_production_3 >>
+#    jobs:
+#      - persist_parameters:
+#          name: persist parameters production
+#          param_workspace: production
+#          environment_title: Rehearsal-Manual
+#      - get_latest_image:
+#          name: get latest tag production
+#          requires: [persist parameters production]
+#          image_tag: production
 #      - run_task:
 #          name: migration - response api tests production
-#          requires: [ migration - validation production ]
+#          requires: [persist parameters production]
 #          tf_workspace: production
 #          runner_command: migration-response-api-tests
 #      - run_task:
 #          name: migration - light touch api tests production
-#          requires: [ migration - response api tests production ]
+#          requires: [migration - response api tests production]
 #          tf_workspace: production
 #          runner_command: migration-light-touch-api-tests
-#      - scale-services:
-#          name: scale up poller service for migration production
-#          requires: [migration - light touch api tests production]
-#          replicas: "1"
-#          profile: "migrations-ci-sirius-production"
-#          service: "notify-poller"
-#          cluster: "production"
 #      - run_elasticsearch_reset:
 #          name: full reindex elasticsearch production
 #          requires: [scale up poller service for migration production]
 #          tf_workspace: production
-      - job_complete:
-          name: job complete notification
+#      - job_complete:
+#          name: job complete notification
 #          requires: [full reindex elasticsearch production]
-          requires: [build infra production]
-          workspace: production
+#          workspace: production
 
-  rehearsal:
+  rehearsal_1:
     when:
       and:
         - equal: [main, << pipeline.git.branch >>]
-        - << pipeline.parameters.run_rehearsal >>
+        - << pipeline.parameters.run_rehearsal_1 >>
     jobs:
       - persist_parameters:
           name: persist parameters rehearsal
@@ -523,19 +599,9 @@ workflows:
           requires: [plan infra rehearsal]
           tf_workspace: rehearsal
           tf_command: apply
-      - scale-services:
-          name: scale down poller service for migration rehearsal
-          requires: [build infra rehearsal]
-          replicas: "0"
-          profile: "migrations-ci-sirius-rehearsal"
-          service: "notify-poller"
-          cluster: "rehearsal"
       - run_task:
           name: migration - initialise environments rehearsal
-          requires: [
-            build infra rehearsal,
-            scale down poller service for migration rehearsal
-         ]
+          requires: [build infra rehearsal]
           runner_command: migration-initialise-environments
           tf_workspace: rehearsal
       - run_task:
@@ -558,6 +624,25 @@ workflows:
           requires: [migration - transform rehearsal]
           tf_workspace: rehearsal
           runner_command: migration-integration
+      - job_complete:
+          name: job complete notification
+          requires: [migration - integration rehearsal]
+          workspace: rehearsal
+
+  rehearsal_2:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - << pipeline.parameters.run_rehearsal_2 >>
+    jobs:
+      - persist_parameters:
+          name: persist parameters rehearsal
+          param_workspace: rehearsal
+          environment_title: Rehearsal-Manual
+      - get_latest_image:
+          name: get latest tag rehearsal
+          requires: [persist parameters rehearsal]
+          image_tag: rehearsal
       - run_task:
           name: migration - load sirius rehearsal
           requires: [migration - integration rehearsal]
@@ -568,9 +653,28 @@ workflows:
           requires: [migration - load sirius rehearsal]
           tf_workspace: rehearsal
           runner_command: migration-validation
+      - job_complete:
+          name: job complete notification
+          requires: [migration - validation rehearsal]
+          workspace: rehearsal
+
+  rehearsal_3:
+    when:
+      and:
+        - equal: [main, << pipeline.git.branch >>]
+        - << pipeline.parameters.run_rehearsal_3 >>
+    jobs:
+      - persist_parameters:
+          name: persist parameters rehearsal
+          param_workspace: rehearsal
+          environment_title: Rehearsal-Manual
+      - get_latest_image:
+          name: get latest tag rehearsal
+          requires: [persist parameters rehearsal]
+          image_tag: rehearsal
       - run_task:
           name: migration - response api tests rehearsal
-          requires: [migration - validation rehearsal]
+          requires: [persist parameters rehearsal]
           tf_workspace: rehearsal
           runner_command: migration-response-api-tests
       - run_task:
@@ -578,13 +682,6 @@ workflows:
           requires: [migration - response api tests rehearsal]
           tf_workspace: rehearsal
           runner_command: migration-light-touch-api-tests
-      - scale-services:
-          name: scale up poller service for migration rehearsal
-          requires: [migration - light touch api tests rehearsal]
-          replicas: "1"
-          profile: "migrations-ci-sirius-rehearsal"
-          service: "notify-poller"
-          cluster: "rehearsal"
       - run_elasticsearch_reset:
           name: full reindex elasticsearch rehearsal
           requires: [scale up poller service for migration rehearsal]
@@ -1347,16 +1444,9 @@ jobs:
       - run:
           name: Reset Elasticsearch
           command: ecs-runner -task reindex-elasticsearch-by-date -timeout 18000
-          background: true
-      - run:
-          name: elasticsearch
-          command: |
-            echo "We're running reindex in the background."
-            echo "We don't want to completely wait for it here."
-            echo "Sleeping for 5 mins so we can see that it has started properly. Check AWS logs for full results"
-            sleep 300
       - notififications/notify_env_vars
       - notififications/notify_if_fail
+
   reset_sirius:
     executor: terraform/terraform
     resource_class: small

--- a/docker-compose.sirius.yml
+++ b/docker-compose.sirius.yml
@@ -119,6 +119,7 @@ services:
       LIGHT_TOUCH_COUNT: 200
       API_TEST_PASSWORD: "Password1" # pragma: allowlist secret
       SIRIUS_FRONT_URL: http://host.docker.internal:8080
+      SIRIUS_FRONT_USER: case.manager@opgtest.com
       S3_URL: http://localstack:4598
     depends_on: [casrec_db]
   wait-for-it:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,7 @@ services:
       ENVIRONMENT: local
       SIRIUS_ACCOUNT: NA
       S3_URL: http://localstack:4572
+      SIRIUS_FRONT_USER: case.manager@opgtest.com
     depends_on: [casrec_db, postgres-sirius]
   wait-for-it:
     build: ./wait-for-it

--- a/migrate_tagged_version.sh
+++ b/migrate_tagged_version.sh
@@ -6,8 +6,12 @@ ENV_VARS=$(cat <<-END
     1. Preproduction\n
     2. PreQA\n
     3. QA\n
-    4. Rehearsal\n
-    5. Production\n
+    4. Rehearsal_1\n
+    5. Rehearsal_2\n
+    6. Rehearsal_3\n
+    7. Production_1\n
+    8. Production_2\n
+    9. Production_3\n
 END
 )
 
@@ -64,40 +68,108 @@ then
   RUN_PREPROD="true"
   RUN_PRE_QA="false"
   RUN_QA="false"
-  RUN_REHEARSAL="false"
-  RUN_PROD="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
 elif [ $ENVIRONMENT == "2" ]
 then
   ENV="PreQA"
   RUN_PREPROD="false"
   RUN_PRE_QA="true"
   RUN_QA="false"
-  RUN_REHEARSAL="false"
-  RUN_PROD="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
 elif [ $ENVIRONMENT == "3" ]
 then
   ENV="QA"
   RUN_PREPROD="false"
   RUN_PRE_QA="false"
   RUN_QA="true"
-  RUN_REHEARSAL="false"
-  RUN_PROD="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
 elif [ $ENVIRONMENT == "4" ]
 then
-  ENV="Rehearsal"
+  ENV="Rehearsal_1"
   RUN_PREPROD="false"
   RUN_PRE_QA="false"
   RUN_QA="false"
-  RUN_REHEARSAL="true"
-  RUN_PROD="false"
+  RUN_REHEARSAL_1="true"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
 elif [ $ENVIRONMENT == "5" ]
 then
-  ENV="Production"
+  ENV="Rehearsal_2"
   RUN_PREPROD="false"
   RUN_PRE_QA="false"
   RUN_QA="false"
-  RUN_REHEARSAL="false"
-  RUN_PROD="true"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="true"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
+elif [ $ENVIRONMENT == "6" ]
+then
+  ENV="Rehearsal_3"
+  RUN_PREPROD="false"
+  RUN_PRE_QA="false"
+  RUN_QA="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="true"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
+elif [ $ENVIRONMENT == "7" ]
+then
+  ENV="Production_1"
+  RUN_PREPROD="false"
+  RUN_PRE_QA="false"
+  RUN_QA="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="true"
+  RUN_PROD_2="false"
+  RUN_PROD_3="false"
+elif [ $ENVIRONMENT == "8" ]
+then
+  ENV="Production_2"
+  RUN_PREPROD="false"
+  RUN_PRE_QA="false"
+  RUN_QA="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="true"
+  RUN_PROD_3="false"
+elif [ $ENVIRONMENT == "9" ]
+then
+  ENV="Production_3"
+  RUN_PREPROD="false"
+  RUN_PRE_QA="false"
+  RUN_QA="false"
+  RUN_REHEARSAL_1="false"
+  RUN_REHEARSAL_2="false"
+  RUN_REHEARSAL_3="false"
+  RUN_PROD_1="false"
+  RUN_PROD_2="false"
+  RUN_PROD_3="true"
 else
   echo "You need to choose a valid option from [1-5]. Exiting...."
   exit 1
@@ -112,7 +184,7 @@ then
               --url https://circleci.com/api/v2/project/github/ministryofjustice/opg-data-casrec-migration/pipeline \
               --header "Circle-Token: ${CIRCLE_TOKEN}" \
               --header 'content-type: application/json' \
-              --data "{\"branch\":\"main\", \"parameters\":{\"run_main\": false, \"run_preprod\": $RUN_PREPROD, \"run_qa\": $RUN_QA, \"run_preqa\": $RUN_PRE_QA, \"run_rehearsal\": $RUN_REHEARSAL, \"run_production\": $RUN_PROD, \"override_tag\": \"$TAG\"}}"
+              --data "{\"branch\":\"main\", \"parameters\":{\"run_main\": false, \"run_preprod\": $RUN_PREPROD, \"run_qa\": $RUN_QA, \"run_preqa\": $RUN_PRE_QA, \"run_rehearsal_1\": $RUN_REHEARSAL_1, \"run_rehearsal_2\": $RUN_REHEARSAL_2, \"run_rehearsal_3\": $RUN_REHEARSAL_3, \"run_production_1\": $RUN_PROD_1, \"run_production_2\": $RUN_PROD_2, \"run_production_3\": $RUN_PROD_3, \"override_tag\": \"$TAG\"}}"
 else
   echo "You chose not to deploy. Good bye!"
   exit 0

--- a/migration_steps/.env
+++ b/migration_steps/.env
@@ -16,3 +16,4 @@ SIRIUS_ACCOUNT=288342028542
 SIRIUS_FRONT_URL=http://localhost:8080
 API_TEST_PASSWORD=Password1 # pragma: allowlist secret
 ACCOUNT_NAME=local
+SIRIUS_FRONT_USER=case.manager@opgtest.com

--- a/migration_steps/load_to_sirius/load_to_sirius.sh
+++ b/migration_steps/load_to_sirius/load_to_sirius.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 set -e
-# envcheck - leaving this here to make absolutely sure we can't change prod without noticing
-if [ "${ENVIRONMENT}" == "local" ] \
-  || [ "${ENVIRONMENT}" == "development" ] \
-  || [ "${ENVIRONMENT}" == "preproduction" ] \
-  || [ "${ENVIRONMENT}" == "preqa" ] \
-  || [ "${ENVIRONMENT}" == "qa" ]
-  then
-  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-  python3 "${DIR}/move_data/app.py"
-  python3 "${DIR}/post_migration_db_tasks/app.py"
-else
-  echo "This job should not run on ${ENVIRONMENT}"
-fi
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+python3 "${DIR}/move_data/app.py"
+python3 "${DIR}/post_migration_db_tasks/app.py"

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -47,16 +47,6 @@ class BaseConfig:
         },
     }
 
-    env_users = {
-        "local": "case.manager@opgtest.com",
-        "development": "case.manager@opgtest.com",
-        "preproduction": "opg+siriussmoketest@digital.justice.gov.uk",
-        "preqa": "opg+siriussmoketest@digital.justice.gov.uk",
-        "qa": "opg+siriussmoketest@digital.justice.gov.uk",
-        "rehearsal": "opg+siriussmoketest@digital.justice.gov.uk",
-        "production": "opg+siriussmoketest@digital.justice.gov.uk",
-    }
-
     schemas = {
         "pre_transform": "casrec_csv",
         "post_transform": "transform",
@@ -130,39 +120,25 @@ class BaseConfig:
     }
 
     def enabled_feature_flags(self, env):
-        if env in [
-            "development",
-            "preproduction",
-            "qa",
-            "preqa",
-            "rehearsal",
-            "production",
-        ]:
+        if env is None or env == "local":
+            enabled_flags = [
+                k for k, v in self.LOCAL_FEATURE_FLAGS.items() if v is True
+            ]
+        else:
             all_flags = list(self.LOCAL_FEATURE_FLAGS.keys())
             enabled_flags = list(
                 flag
                 for flag in all_flags
                 if get_paramstore_value(f"{env}-{flag}") == "True"
             )
-        else:
-            enabled_flags = [
-                k for k, v in self.LOCAL_FEATURE_FLAGS.items() if v is True
-            ]
         return enabled_flags
 
     def allowed_entities(self, env):
-        if env in [
-            "development",
-            "preproduction",
-            "qa",
-            "preqa",
-            "rehearsal",
-            "production",
-        ]:
+        if env is None or env == "local":
+            allowed_entity_list = self.LOCAL_ENTITIES
+        else:
             entities = get_paramstore_value(f"{env}-allowed-entities")
             allowed_entity_list = entities.split(",")
-        else:
-            allowed_entity_list = self.LOCAL_ENTITIES
 
         if len(allowed_entity_list) > 0:
             return allowed_entity_list
@@ -173,14 +149,9 @@ class BaseConfig:
     def get_filtered_correfs(self, env, console_correfs):
         filter_correfs = ""
 
-        if env in [
-            "development",
-            "preproduction",
-            "preqa",
-            "qa",
-            "rehearsal",
-            "production",
-        ]:
+        if env is None or env == "local":
+            pass
+        else:
             param_correfs = get_paramstore_value(f"{env}-correfs")
             if param_correfs == "0":
                 log.info(f"No filtering requested, proceed with migrating all Correfs.")

--- a/migration_steps/shared/config.py
+++ b/migration_steps/shared/config.py
@@ -53,6 +53,7 @@ class BaseConfig:
         "preproduction": "opg+siriussmoketest@digital.justice.gov.uk",
         "preqa": "opg+siriussmoketest@digital.justice.gov.uk",
         "qa": "opg+siriussmoketest@digital.justice.gov.uk",
+        "rehearsal": "opg+siriussmoketest@digital.justice.gov.uk",
         "production": "opg+siriussmoketest@digital.justice.gov.uk",
     }
 
@@ -91,7 +92,15 @@ class BaseConfig:
 
     DEFAULT_CHUNK_SIZE = int(os.environ.get("DEFAULT_CHUNK_SIZE", 20000))
 
-    ALL_ENVIRONMENTS = ["local", "development", "preproduction", "qa", "preqa"]
+    ALL_ENVIRONMENTS = [
+        "local",
+        "development",
+        "preproduction",
+        "qa",
+        "preqa",
+        "rehearsal",
+        "production",
+    ]
     LOCAL_ENTITIES = [
         "clients",
         "cases",
@@ -121,7 +130,14 @@ class BaseConfig:
     }
 
     def enabled_feature_flags(self, env):
-        if env in ["development", "preproduction", "qa", "preqa", "production"]:
+        if env in [
+            "development",
+            "preproduction",
+            "qa",
+            "preqa",
+            "rehearsal",
+            "production",
+        ]:
             all_flags = list(self.LOCAL_FEATURE_FLAGS.keys())
             enabled_flags = list(
                 flag
@@ -135,7 +151,14 @@ class BaseConfig:
         return enabled_flags
 
     def allowed_entities(self, env):
-        if env in ["development", "preproduction", "qa", "preqa", "production"]:
+        if env in [
+            "development",
+            "preproduction",
+            "qa",
+            "preqa",
+            "rehearsal",
+            "production",
+        ]:
             entities = get_paramstore_value(f"{env}-allowed-entities")
             allowed_entity_list = entities.split(",")
         else:
@@ -150,7 +173,14 @@ class BaseConfig:
     def get_filtered_correfs(self, env, console_correfs):
         filter_correfs = ""
 
-        if env in ["development", "preproduction", "preqa", "qa", "production"]:
+        if env in [
+            "development",
+            "preproduction",
+            "preqa",
+            "qa",
+            "rehearsal",
+            "production",
+        ]:
             param_correfs = get_paramstore_value(f"{env}-correfs")
             if param_correfs == "0":
                 log.info(f"No filtering requested, proceed with migrating all Correfs.")

--- a/migration_steps/validation/api_tests/shared/api_test.py
+++ b/migration_steps/validation/api_tests/shared/api_test.py
@@ -42,10 +42,10 @@ class ApiTests:
         self.log_assert_to_screen = (
             True if os.environ.get("ENVIRONMENT") in ["local", "development"] else False
         )
-        self.user = self.config.env_users[self.environment]
+        self.user = os.environ.get("SIRIUS_FRONT_USER")
         self.account_name = (
             os.environ.get("ACCOUNT_NAME")
-            if os.environ.get("ACCOUNT_NAME") not in ["qa", "preqa", "rehearsal"]
+            if os.environ.get("ACCOUNT_NAME") not in ["qa", "preqa"]
             else "preproduction"
         )
         self.password = os.environ.get("API_TEST_PASSWORD")
@@ -69,6 +69,8 @@ class ApiTests:
         cookie = response.headers["Set-Cookie"]
         xsrf = response.headers["X-XSRF-TOKEN"]
         headers_dict = {"Cookie": cookie, "x-xsrf-token": xsrf}
+
+        self.api_log(f"TESTING: {self.user} - {self.password}")
         data = {"email": self.user, "password": self.password}
         with requests.Session() as s:
             p = s.post(f"{self.base_url}/auth/login", data=data, headers=headers_dict)

--- a/migration_steps/validation/api_tests/shared/api_test.py
+++ b/migration_steps/validation/api_tests/shared/api_test.py
@@ -45,7 +45,7 @@ class ApiTests:
         self.user = self.config.env_users[self.environment]
         self.account_name = (
             os.environ.get("ACCOUNT_NAME")
-            if os.environ.get("ACCOUNT_NAME") not in ["qa", "preqa"]
+            if os.environ.get("ACCOUNT_NAME") not in ["qa", "preqa", "rehearsal"]
             else "preproduction"
         )
         self.password = os.environ.get("API_TEST_PASSWORD")
@@ -440,7 +440,9 @@ class ApiTests:
         log.debug(f"returning: {endpoint_final}")
         return endpoint_final
 
-    def assert_on_fields(self, formatted_api_response, row, entity_ref, json_locator, exact_match):
+    def assert_on_fields(
+        self, formatted_api_response, row, entity_ref, json_locator, exact_match
+    ):
         # Where we have multiple entity_ids we need rationalise the grouped responses
         col_restruct_text = self.restructure_text(formatted_api_response["api_result"])
         formatted_api_response["api_result"] = col_restruct_text
@@ -541,7 +543,7 @@ class ApiTests:
             entity_ref = row["entity_ref"]
             json_locator = row["json_locator"]
             test_purpose = row["test_purpose"]
-            exact_match = False if test_purpose[:9] == 'includes_' else True
+            exact_match = False if test_purpose[:9] == "includes_" else True
 
             if entity_ref not in self.filtered_cases:
                 # Get the ids to perform the search on based on the caserecnumber
@@ -559,7 +561,11 @@ class ApiTests:
                 if formatted_api_response:
                     # Loop through and check expected results against actual for each field
                     self.assert_on_fields(
-                        formatted_api_response, row, entity_ref, json_locator, exact_match
+                        formatted_api_response,
+                        row,
+                        entity_ref,
+                        json_locator,
+                        exact_match,
                     )
                 else:
                     self.api_log("empty dictionary returned!")

--- a/scripts/api_tests_generator/app.py
+++ b/scripts/api_tests_generator/app.py
@@ -71,6 +71,7 @@ def create_a_session(base_url, password):
         "development": "case.manager@opgtest.com",
         "preqa": "opg+siriussmoketest@digital.justice.gov.uk",
         "preproduction": "opg+siriussmoketest@digital.justice.gov.uk",
+        "rehearsal": "opg+siriussmoketest@digital.justice.gov.uk",
         "qa": "opg+siriussmoketest@digital.justice.gov.uk",
         "production": "opg+siriussmoketest@digital.justice.gov.uk",
     }

--- a/scripts/api_tests_generator/app.py
+++ b/scripts/api_tests_generator/app.py
@@ -66,16 +66,7 @@ def get_session(base_url, user, password):
 
 
 def create_a_session(base_url, password):
-    env_users = {
-        "local": "case.manager@opgtest.com",
-        "development": "case.manager@opgtest.com",
-        "preqa": "opg+siriussmoketest@digital.justice.gov.uk",
-        "preproduction": "opg+siriussmoketest@digital.justice.gov.uk",
-        "rehearsal": "opg+siriussmoketest@digital.justice.gov.uk",
-        "qa": "opg+siriussmoketest@digital.justice.gov.uk",
-        "production": "opg+siriussmoketest@digital.justice.gov.uk",
-    }
-    user = env_users[environment]
+    user = os.environ.get("SIRIUS_FRONT_USER")
     sess, headers_dict, status_code = get_session(base_url, user, password)
     session = {
         "sess": sess,

--- a/scripts/ci_scripts/run_step_function.py
+++ b/scripts/ci_scripts/run_step_function.py
@@ -184,6 +184,7 @@ def main(role, account, wait_for, workspace, sf_name_suffix):
         "development": "288342028542",
         "preproduction": "492687888235",
         "preqa": "492687888235",
+        "rehearsal": "492687888235",
         "qa": "492687888235",
     }
     account_id = account_map[account]

--- a/scripts/ci_scripts/run_step_function.py
+++ b/scripts/ci_scripts/run_step_function.py
@@ -186,6 +186,7 @@ def main(role, account, wait_for, workspace, sf_name_suffix):
         "preqa": "492687888235",
         "rehearsal": "492687888235",
         "qa": "492687888235",
+        "production": "649098267436",
     }
     account_id = account_map[account]
     sf_name = f"{sf_name_suffix}-{workspace}"

--- a/terraform/environment/ecs_etl5_validate.tf
+++ b/terraform/environment/ecs_etl5_validate.tf
@@ -39,6 +39,10 @@ locals {
         name      = "API_TEST_PASSWORD"
         valueFrom = aws_secretsmanager_secret.api_tests.arn
       },
+      {
+        name      = "SIRIUS_FRONT_USER"
+        valueFrom = aws_secretsmanager_secret.api_tests_user.arn
+      }
     ],
     environment = [
       {

--- a/terraform/environment/secrets.tf
+++ b/terraform/environment/secrets.tf
@@ -16,6 +16,15 @@ data "aws_secretsmanager_secret_version" "api_tests" {
   secret_id = aws_secretsmanager_secret.api_tests.id
 }
 
+resource "aws_secretsmanager_secret" "api_tests_user" {
+  name = "${local.account.name}/migration-api-test-user"
+  tags = local.default_tags
+}
+
+data "aws_secretsmanager_secret_version" "api_tests_user" {
+  secret_id = aws_secretsmanager_secret.api_tests.id
+}
+
 resource "aws_secretsmanager_secret" "circle_token" {
   count = local.account.name == "development" ? 1 : 0
   name  = "${local.account.name}/migration_circleci_token"


### PR DESCRIPTION
## Purpose

Second part in hopefully not a trilogy of fixes based on the rehearsal run.

## Approach

Sec group for ES had changed and have removed background nature of job now it's much quicker
Cut out as much looks ups bases on a dict as possible so avoid worrying about putting the entries in the dict and having it centralised.
Moved more into terraform variables
As we're bringing sirius down manually we need to split up the job so that we bring it all up again before running API tests. Actually decided to split it in 3 to give clear check points with one split before the load stage where we can check staging validation.

## Learning

Not really, just fiddly 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
