### PR TITLE
IN-1155 remove updateddate from validation

### DIFF
--- a/migration_steps/prepare_source_data/counts_verification/sql/count_cp1.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/count_cp1.sql
@@ -37,7 +37,7 @@ WHERE supervision_table = 'persons_clients';
 
 -- persons_deputies
 DROP TABLE IF EXISTS countverificationaudit.{working_column}_persons_deputies;
-SELECT id, caserecnumber INTO countverificationaudit.{working_column}_persons_deputies FROM countverification.cp1_cases;
+SELECT id INTO countverificationaudit.{working_column}_persons_deputies FROM countverification.cp1_deputies;
 UPDATE countverification.counts
 SET {working_column} = (
     SELECT COUNT(*) FROM countverificationaudit.{working_column}_persons_deputies

--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -243,7 +243,8 @@
             "middlenames",
             "uid",
             "feepayer_id",
-            "clientstatus"
+            "clientstatus",
+            "updateddate"
         ],
         "casenumber_source": "client_persons.caserecnumber",
         "orderby": {},
@@ -273,7 +274,8 @@
     },
     "client_phonenumbers": {
         "exclude": [
-            "person_id"
+            "person_id",
+            "updateddate"
         ],
         "casenumber_source": "client_persons.caserecnumber",
         "orderby": {},
@@ -495,7 +497,8 @@
     },
     "deputy_daytime_phonenumbers": {
         "exclude": [
-            "person_id"
+            "person_id",
+            "updateddate"
         ],
         "casenumber_source": "cases.caserecnumber",
         "orderby": {
@@ -543,7 +546,8 @@
     },
     "deputy_evening_phonenumbers": {
         "exclude": [
-            "person_id"
+            "person_id",
+            "updateddate"
         ],
         "casenumber_source": "cases.caserecnumber",
         "orderby": {
@@ -669,7 +673,8 @@
             "dateofdeath",
             "middlenames",
             "uid",
-            "deputycasrecid"
+            "deputycasrecid",
+            "updateddate"
         ],
         "casenumber_source": "cases.caserecnumber",
         "orderby": {

--- a/migration_steps/validation/validate_db/app/sql/fixed_sql/scheduled_events_reporting.sql
+++ b/migration_steps/validation/validate_db/app/sql/fixed_sql/scheduled_events_reporting.sql
@@ -9,6 +9,10 @@ CREATE TABLE casrec_csv.exceptions_scheduled_events_reporting(
     enddate text default NULL
 );
 
+CREATE INDEX ix_scheduled_events_json_payload ON {target_schema}.scheduled_events USING BTREE ((event->'payload'->>'reportingPeriodId'));
+CREATE INDEX ix_scheduled_events_json_clientid ON {target_schema}.scheduled_events USING BTREE ((event->'payload'->>'clientId'));
+CREATE INDEX ix_scheduled_events_json_class ON {target_schema}.scheduled_events USING BTREE ((event->>'class'));
+
 INSERT INTO casrec_csv.exceptions_scheduled_events_reporting(
 	SELECT * FROM (
         SELECT
@@ -48,3 +52,7 @@ INSERT INTO casrec_csv.exceptions_scheduled_events_reporting(
             AND annual_report_logs.status = 'PENDING'
     ) AS sirius_events_data
 );
+
+DROP INDEX IF EXISTS ix_scheduled_events_json_payload;
+DROP INDEX IF EXISTS ix_scheduled_events_json_clientid;
+DROP INDEX IF EXISTS ix_scheduled_events_json_class;

--- a/terraform/shared/terraform.tfvars.json
+++ b/terraform/shared/terraform.tfvars.json
@@ -6,7 +6,7 @@
       "vpc_id": "vpc-6809cc0f",
       "is_production": true,
       "db_subnet_prefix": "prod",
-      "s3_path": "live2",
+      "s3_path": "live",
       "account_name": "production"
     },
     "preproduction": {


### PR DESCRIPTION
## Purpose

Removed the updateddate from validation as we know it works and if we ever do anything on separate days then it puts all our validation out which could lead to a lot of stress on the migration day.

Also was looking at worst performing areas and got this query down from 25 mins to a few seconds. The next worst is also a json query but no matter what i tried I couldn't get it to use the indexes.

## Approach

NA

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
