### PR TITLE
IN-1160 Fix bug where PENDING reporting period dates cannot be edited 

### DIFF
--- a/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_logs_pending.py
+++ b/migration_steps/transform_casrec/transform/app/entities/reporting/annual_report_logs_pending.py
@@ -95,6 +95,7 @@ def insert_annual_report_logs_pending(db_config, target_db, mapping_file):
             SELECT
                 "Report Due" AS reportingperiodenddate,
                 'PENDING' AS status,
+                'NO_REVIEW' AS reviewstatus,
                 0 AS numberofchaseletters,
                 "Case" AS c_case
             FROM {db_config["source_schema"]}.pat

--- a/migration_steps/validation/api_test_data_s3_upload/app/validation/api_tests/reports.csv
+++ b/migration_steps/validation/api_test_data_s3_upload/app/validation/api_tests/reports.csv
@@ -9,6 +9,8 @@ endpoint,entity_ref,json_locator,test_purpose,api_response
 /api/v1/clients/{id}/annual-reports,10303376,[0].status.handle,incomplete_status,INCOMPLETE
 /api/v1/clients/{id}/annual-reports,94055780,[0].status.handle,pending_status,PENDING
 /api/v1/clients/{id}/annual-reports,94055780,[0].reviewStatus.handle,no_review_status,NO_REVIEW
+/api/v1/clients/{id}/annual-reports,10016235,[0].status.handle,pending_status_from_pat_table,PENDING
+/api/v1/clients/{id}/annual-reports,10016235,[0].reviewStatus.handle,no_review_status_from_pat_table,NO_REVIEW
 /api/v1/clients/{id}/annual-reports,10005928,[0].status.handle,due_status,DUE
 /api/v1/clients/{id}/annual-reports,10005928,[0].reviewStatus.handle,no_review_status,NO_REVIEW
 /api/v1/clients/{id}/annual-reports,10461469,[0].status.handle,overdue_status,OVERDUE

--- a/migration_steps/validation/validate_db/app/sql/fixed_sql/annual_report_logs.sql
+++ b/migration_steps/validation/validate_db/app/sql/fixed_sql/annual_report_logs.sql
@@ -81,7 +81,7 @@ INSERT INTO casrec_csv.exceptions_annual_report_logs(
             NULL AS revisedduedate,
             0 AS numberofchaseletters,
             'PENDING' AS status,
-            NULL AS review_status,
+            'NO_REVIEW' AS review_status,
             NULL AS reviewdate
         FROM
             casrec_csv.pat p


### PR DESCRIPTION
## Purpose

[IN-1160](https://opgtransform.atlassian.net/browse/IN-1160)

## Approach

reviewdate was missing for PENDING reports, so set to NO_REVIEW as a default.

## Learning

n/a

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
