### PR TITLE
In 1163 orderdeputy status

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -1474,5 +1474,42 @@
           "column": "",
           "identifiers": []
         }
+    },
+    "order_deputy": {
+        "exclude": [
+            "order_id",
+            "deputy_id",
+            "statuschangedate"
+        ],
+        "casenumber_source": "cases.caserecnumber",
+        "orderby": {},
+        "casrec": {
+            "from_table": "deputyship",
+            "transform": {
+                "statusoncase": "CASE WHEN casrec_csv.deputyship.\"Joint\" = '5' THEN 'CLOSED' ELSE NULLIF(TRIM(casrec_csv.deputy_status_lookup(casrec_csv.deputy.\"Stat\")), '') END",
+                "statusoncaseoverride": "CASE WHEN casrec_csv.deputyship.\"Joint\" = '5' THEN 'DISCHARGED' ELSE NULLIF(TRIM(casrec_csv.deputy_override_lookup(casrec_csv.deputy.\"Stat\")), '') END"
+            },
+            "joins": [
+                "LEFT JOIN casrec_csv.order ON casrec_csv.order.\"Order No\" = casrec_csv.deputyship.\"Order No\"",
+                "LEFT JOIN casrec_csv.deputy ON casrec_csv.deputyship.\"Deputy No\" = casrec_csv.deputy.\"Deputy No\""
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_order_deputy exc_table ON exc_table.caserecnumber = casrec_csv.order.\"Case\"",
+            "where_clauses": [
+                "casrec_csv.order.\"Ord Stat\" != 'Open'"
+            ]
+        },
+        "sirius": {
+            "from_table": "order_deputy",
+            "transform": {},
+            "joins": [
+                "LEFT JOIN {target_schema}.cases ON cases.id = order_deputy.order_id"
+            ],
+            "exception_table_join": "LEFT JOIN casrec_csv.exceptions_order_deputy exc_table ON exc_table.caserecnumber = cases.caserecnumber",
+            "where_clauses": []
+        },
+        "manual_checks": {
+          "column": "",
+          "identifiers": []
+        }
     }
 }

--- a/migration_steps/validation/validate_db/app/app.py
+++ b/migration_steps/validation/validate_db/app/app.py
@@ -66,6 +66,7 @@ def get_mappings():
             "deputy_evening_phonenumbers",
             "deputy_feepayer_id",
             "deputy_addresses",
+            "order_deputy",
         ],
         "bonds": ["bonds_active", "bonds_dispensed"],
         "warnings": [


### PR DESCRIPTION
## Purpose

We had a problem that the overall deputy status was being applied to the deputyship (in Sirius data terms, the row in the order_deputy table).

This is ok in most cases, except where casrec_csv.deputyhip.joint = '5' - in which case we need to override the deputyship data as follows:

(Sirius)
order_deputy.statusoncase = 'CLOSED'
order_deputy.statusoncaseoverride = 'DISCHARGED'

## Approach

After discussion with Elliot, a transform seemed like overkill - Added a couple of tiny helper functions to do the conditional dataframe field change.

When I came to add test coverage - I discovered that the order_deputy table wasn't covered by automated db validation, so added this in.

## Learning

Pandas is simple when you know how.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
