### PR TITLE
IN-1135c more delete count validation

### DIFF
--- a/migration_steps/prepare_source_data/counts_verification/sql/count_casrec_source.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/count_casrec_source.sql
@@ -463,6 +463,21 @@ UPDATE countverification.counts SET {working_column} =
 )
 WHERE supervision_table = 'person_warning';
 
+-- deputy_person_document (not migrating)
+UPDATE countverification.counts
+SET {working_column} = 0
+WHERE supervision_table = 'deputy_person_document';
+
+-- deputy_person_document (not migrating)
+UPDATE countverification.counts
+SET {working_column} = 0
+WHERE supervision_table = 'person_document';
+
+-- caseitem_document (not migrating)
+UPDATE countverification.counts
+SET {working_column} = 0
+WHERE supervision_table = 'caseitem_document';
+
 DROP INDEX IF EXISTS countverification.filteredorder_orderno_idx;
 DROP INDEX IF EXISTS countverification.filteredorder_case_idx;
 DROP INDEX IF EXISTS countverification.filtereddeps_deputynumber_idx;

--- a/migration_steps/prepare_source_data/counts_verification/sql/count_cp1.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/count_cp1.sql
@@ -457,3 +457,32 @@ SET {working_column} =(
     SELECT COUNT(*) FROM countverificationaudit.{working_column}_person_timeline
 )
 WHERE supervision_table = 'person_timeline';
+
+-- person_document
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*)
+    FROM person_document pt
+    INNER JOIN countverification.cp1_clients cp1
+    ON cp1.id = pt.person_id
+)
+WHERE supervision_table = 'person_document';
+
+-- deputy_person_document
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*)
+    FROM person_document pt
+    INNER JOIN countverification.cp1_deputies ncp1
+    ON ncp1.id = pt.person_id
+)
+WHERE supervision_table = 'deputy_person_document';
+
+-- caseitem_document
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*) FROM caseitem_document cd
+    INNER JOIN countverification.cp1_cases c
+        ON cd.caseitem_id = c.id
+)
+WHERE supervision_table = 'caseitem_document';

--- a/migration_steps/prepare_source_data/counts_verification/sql/count_non_cp1.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/count_non_cp1.sql
@@ -451,3 +451,32 @@ SET {working_column} =(
     SELECT COUNT(*) FROM countverificationaudit.{working_column}_person_timeline
 )
 WHERE supervision_table = 'person_timeline';
+
+-- person_document
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*)
+    FROM person_document pt
+    INNER JOIN countverification.non_cp1_clients ncp1
+    ON ncp1.id = pt.person_id
+)
+WHERE supervision_table = 'person_document';
+
+-- deputy_person_document
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*)
+    FROM person_document pt
+    INNER JOIN countverification.non_cp1_deputies ncp1
+    ON ncp1.id = pt.person_id
+)
+WHERE supervision_table = 'deputy_person_document';
+
+-- caseitem_document
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*) FROM caseitem_document cd
+    INNER JOIN countverification.non_cp1_cases c
+        ON cd.caseitem_id = c.id
+)
+WHERE supervision_table = 'caseitem_document';

--- a/migration_steps/prepare_source_data/counts_verification/sql/count_non_supervision.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/count_non_supervision.sql
@@ -288,7 +288,10 @@ WHERE supervision_table = 'hold_period';
 -- person_document
 UPDATE countverification.counts
 SET {working_column} = (
-    SELECT COUNT(*) FROM person_document
+    SELECT COUNT(*)
+    FROM person_document pt
+    INNER JOIN countverification.lpa_persons lpa
+    ON lpa.id = pt.person_id
 )
 WHERE supervision_table = 'person_document';
 
@@ -320,26 +323,12 @@ SET {working_column} = (
 )
 WHERE supervision_table = 'annual_report_letter_status';
 
--- annual_report_type_assignments
-update countverification.counts
-SET {working_column} = (
-    SELECT COUNT(*) FROM annual_report_type_assignments
-)
-WHERE supervision_table = 'annual_report_type_assignments';
-
 -- caseitem_queue
 update countverification.counts
 SET {working_column} = (
     SELECT COUNT(*) FROM caseitem_queue
 )
 WHERE supervision_table = 'caseitem_queue';
-
--- events
-update countverification.counts
-SET {working_column} = (
-    SELECT COUNT(*) FROM events
-)
-WHERE supervision_table = 'events';
 
 -- finance_invoice_email_status
 update countverification.counts
@@ -442,6 +431,14 @@ WHERE supervision_table = 'uploads';
 -- bond_providers
 -- random_review_settings
 -- firm
+
+
+-- total_documents (adding this here as just want to see count staying the same)
+UPDATE countverification.counts
+SET {working_column} = (
+    SELECT COUNT(*) FROM documents d
+)
+WHERE supervision_table = 'total_documents';
 
 DROP INDEX countverification.lpa_persons_idx;
 DROP INDEX countverification.lpa_cases_idx;

--- a/migration_steps/prepare_source_data/counts_verification/sql/schema_up.sql
+++ b/migration_steps/prepare_source_data/counts_verification/sql/schema_up.sql
@@ -27,7 +27,6 @@ VALUES
 ('document_pages'),
 ('document_secondaryrecipient'),
 ('documents'),
-('events'),
 ('feepayer_id'),
 ('finance_allocation_credits'),
 ('finance_exemptions'),
@@ -73,7 +72,9 @@ VALUES
 ('validation_check'),
 ('visitor'),
 ('visits'),
-('warnings')
+('warnings'),
+('total_documents'),
+('deputy_person_document')
 ;
 
 CREATE SCHEMA IF NOT EXISTS countverificationaudit;


### PR DESCRIPTION
## Purpose

Events is too slow to bring back. Also we can't properly audit it because it's so huge and takes too long. 

Wanted to check our document counts to make sure we're correctly moving the documents.

Added a couple of statuses of 'DELETE - OK' where i wanted to check that delete hadn't gone wrong but it was too hard to work out the figure for the expected after migrate (already covered in validation for one and linking id for the other)

## Learning

Did some very long and laborious setup locally go get the logic right for the document stuff... was very boring

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
