### PR TITLE
IN-1183 Add create time to ordering to disambiguate desired deputyshi…

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -113,7 +113,7 @@
             },
             "joins": [
                 "LEFT JOIN casrec_csv.pat ON casrec_csv.pat.\"Case\" = casrec_csv.order.\"Case\"",
-                "LEFT JOIN (SELECT \"Order No\", \"Joint\" FROM (SELECT \"Order No\", \"Joint\", row_number() OVER (PARTITION BY \"Order No\" ORDER BY \"Create\" DESC) AS rownum FROM (SELECT \"Order No\", \"Joint\", \"Create\" FROM casrec_csv.deputyship WHERE \"Joint\" != '5') AS non_five_deputyships) AS numbered_deputyships WHERE rownum = 1) AS deputyships ON casrec_csv.order.\"Order No\" = deputyships.\"Order No\""
+                "LEFT JOIN (SELECT \"Order No\", \"Joint\" FROM (SELECT \"Order No\", \"Joint\", row_number() OVER (PARTITION BY \"Order No\" ORDER BY \"Create\" DESC, \"at\" DESC) AS rownum FROM (SELECT \"Order No\", \"Joint\", \"Create\", \"at\" FROM casrec_csv.deputyship WHERE \"Joint\" != '5') AS non_five_deputyships) AS numbered_deputyships WHERE rownum = 1) AS deputyships ON casrec_csv.order.\"Order No\" = deputyships.\"Order No\""
             ],
             "exception_table_join": "LEFT JOIN casrec_csv.exceptions_cases exc_table ON exc_table.caserecnumber = pat.\"Case\"",
             "where_clauses": [

--- a/migration_steps/transform_casrec/transform/app/entities/cases/cases.py
+++ b/migration_steps/transform_casrec/transform/app/entities/cases/cases.py
@@ -51,12 +51,13 @@ def insert_cases(db_config, target_db, mapping_file):
             SELECT
                 "Order No",
                 "Joint",
-                row_number() OVER (PARTITION BY "Order No" ORDER BY "Create" DESC) AS rownum
+                row_number() OVER (PARTITION BY "Order No" ORDER BY "Create" DESC, "at" DESC) AS rownum
             FROM (
                 SELECT
                     "Order No",
                     "Joint",
-                    "Create"
+                    "Create",
+                    "at"
                 FROM {db_config["source_schema"]}.deputyship
                 WHERE "Joint" != '5'
             ) AS deputyships


### PR DESCRIPTION
Add create time to ordering to disambiguate desired deputyship joint type

## Purpose

We were getting inconsistent results between implementation and validation in cases where two deputyships have different joint types. (Shouldn't happen, as Heather data cleansed, but is happening in a few cases)

As per ticket https://opgtransform.atlassian.net/browse/IN-1165
we want to take the joint type of the first deputyship ordered by create date descending

This ticket is to also add order by create TIME descending, as we have deputyships with identical create dates, leading to inconsistent ordering of results in SQL 

## Approach

Added "at" column into order both in transform and in validation

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
