### PR TITLE
IN-1195 Cleansing Tasks Duedate

### DIFF
--- a/scripts/post_migration_fixes/pmf_tasks_duedate_20220307_in1195/tasks.sql
+++ b/scripts/post_migration_fixes/pmf_tasks_duedate_20220307_in1195/tasks.sql
@@ -1,0 +1,61 @@
+CREATE SCHEMA if not exists pmf_tasks_duedate_20220307_in1195;
+
+SELECT tasks_id, tasks_duedate AS original_value, expected AS expected_value
+INTO pmf_tasks_duedate_20220307_in1195.tasks_updates
+FROM (
+    SELECT
+        casrec."Case",
+        casrec.sup_activity_target         AS casrec_actual,
+        t.id                               AS tasks_id,
+        t.duedate                          AS tasks_duedate,
+        casrec.activity_tracking_startdate AS expected
+    FROM (
+        SELECT
+            sa."Case",
+            sa."Start Date",
+            sa."Target" AS sup_activity_target,
+            t2."Start Date" AS activity_tracking_startdate
+        FROM
+        casrec_csv.sup_activity sa
+        LEFT JOIN  (
+            SELECT "Case", "Start Date", "Sup ID", "Defn ID", rownum FROM (
+                SELECT "Case", "Start Date", "Sup ID", "Defn ID", row_number() OVER ( PARTITION BY at."Case", at."Sup ID", at."Defn ID" ORDER BY at.casrec_row_id DESC ) AS rownum
+                FROM casrec_csv.activity_tracking at
+            ) t1
+            WHERE rownum = 1
+        ) t2
+        ON t2."Case" = sa."Case"
+        AND t2."Sup ID" = sa."SupID"
+        AND t2."Defn ID" = sa."DefnID"
+        WHERE sa."Status" = 'ACTIVE'
+        ORDER BY sa."Case" ASC
+    ) casrec
+    INNER JOIN persons p ON p.caserecnumber = casrec."Case"
+    INNER JOIN person_task pt ON pt.person_id = p.id
+    INNER JOIN tasks t ON t.id = pt.task_id AND t.duedate = CAST(casrec.sup_activity_target AS DATE)
+    WHERE casrec.sup_activity_target != casrec.activity_tracking_startdate
+) update_wrapper
+;
+
+SELECT t.*
+INTO pmf_tasks_duedate_20220307_in1195.tasks_audit
+FROM pmf_tasks_duedate_20220307_in1195.tasks_updates tu
+INNER JOIN tasks t ON t.id = tu.tasks_id;
+
+BEGIN;
+    UPDATE tasks t SET duedate = CAST(tu.expected_value AS DATE)
+    FROM pmf_tasks_duedate_20220307_in1195.tasks_updates tu
+    WHERE tu.tasks_id = t.id;
+-- Run if counts incorrect
+ROLLBACK;
+-- Run if counts correct
+COMMIT;
+
+-- Validation script (should be 0)
+SELECT tasks_id, CAST(expected_value AS DATE)
+FROM pmf_tasks_duedate_20220307_in1195.tasks_updates tu
+EXCEPT
+SELECT t.id, t.duedate
+FROM tasks t
+INNER JOIN pmf_tasks_duedate_20220307_in1195.tasks_audit au
+    ON au.id = t.id;


### PR DESCRIPTION
What ran in Migration (as per mapping spreadsheet):
tasks.duedate = sup_activity.”Start Date"

Updates made:
Update to use casrec_csv.activity_tracking.“Start Date” of the latest associated row in casrec_csv.activity_tracking

## Purpose

_Briefly describe the purpose of the change, and/or link to the ticket for context_

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
