### PR TITLE
PM08 IN-1182 Migrate supervision level logs from casrec_csv.risk_assessment

### DIFF
--- a/scripts/post_migration_fixes/pmf_sup_level_20220308_in1182/supervision_level_log.sql
+++ b/scripts/post_migration_fixes/pmf_sup_level_20220308_in1182/supervision_level_log.sql
@@ -1,6 +1,8 @@
 CREATE SCHEMA IF NOT EXISTS pmf_sup_level_20220308_in1182;
 
 -- DROP TABLE IF EXISTS pmf_sup_level_20220308_in1182.supervision_level_log_audit;
+-- DROP TABLE IF EXISTS pmf_sup_level_20220308_in1182.supervision_level_log_keep;
+-- DROP TABLE IF EXISTS pmf_sup_level_20220308_in1182.supervision_level_log_deletes;
 -- DROP TABLE IF EXISTS pmf_sup_level_20220308_in1182.supervision_level_log_inserts;
 
 SET datestyle = "ISO, DMY";
@@ -11,6 +13,36 @@ FROM supervision_level_log sll
 INNER JOIN cases c ON c.id = sll.order_id
 INNER JOIN persons p ON p.id = c.client_id
 WHERE p.clientsource = 'CASRECMIGRATION';
+
+WITH migrated_sup_levels AS (
+    SELECT sll.*
+    FROM supervision_level_log sll
+    INNER JOIN cases c ON c.id = sll.order_id
+    INNER JOIN persons p ON p.id = c.client_id
+    WHERE p.clientsource = 'CASRECMIGRATION'
+)
+SELECT *
+INTO pmf_sup_level_20220308_in1182.supervision_level_log_keep
+FROM (
+    SELECT msl.*
+    FROM migrated_sup_levels msl
+    WHERE msl.appliesfrom <> '2022-03-05'::date
+       OR msl.createddate <> '2022-03-05'::timestamp(0)
+       OR msl.notes <> 'placeholder note'
+    UNION
+    SELECT id, order_id, appliesfrom, createddate, supervisionlevel, notes, assetlevel
+    FROM (
+        SELECT *, ROW_NUMBER() OVER (PARTITION BY order_id ORDER BY order_id, id) as row_number
+        FROM migrated_sup_levels
+    ) numbered_logs
+    WHERE numbered_logs.row_number <> 1
+) logs;
+
+SELECT *
+INTO pmf_sup_level_20220308_in1182.supervision_level_log_deletes
+FROM pmf_sup_level_20220308_in1182.supervision_level_log_audit audit
+LEFT JOIN pmf_sup_level_20220308_in1182.supervision_level_log_keep keep ON audit.id = keep.id
+WHERE keep.id IS NULL;
 
 WITH casrec_supervision_levels AS (
     SELECT a.*, ROW_NUMBER() OVER (ORDER BY a."Order No", a."Start Date"::date) AS row_number
@@ -43,8 +75,8 @@ ORDER BY csl1.row_number;
 
 BEGIN;
     DELETE FROM supervision_level_log sll
-    USING pmf_sup_level_20220308_in1182.supervision_level_log_audit slla
-    WHERE sll.id = slla.id;
+    USING pmf_sup_level_20220308_in1182.supervision_level_log_deletes del
+    WHERE sll.id = del.id;
 
     INSERT INTO supervision_level_log (id, order_id, appliesfrom, createddate, supervisionlevel, notes, assetlevel)
     SELECT nextval('supervision_level_log_id_seq'), slli.order_id, slli.appliesfrom, slli.createddate, slli.supervisionlevel, slli.notes, slli.assetlevel
@@ -76,4 +108,10 @@ SELECT 'not in Casrec' as validation, * FROM (
     SELECT * FROM sirius_side
     EXCEPT
     SELECT * FROM casrec_side
-) validation2;
+) validation2
+UNION
+SELECT 'erroneously deleted' as validation, * FROM (
+    SELECT order_id, appliesfrom, createddate, supervisionlevel, notes, assetlevel FROM pmf_sup_level_20220308_in1182.supervision_level_log_keep
+    EXCEPT
+    SELECT * FROM sirius_side
+) validation3;

--- a/scripts/post_migration_fixes/pmf_sup_level_20220308_in1182/supervision_level_log.sql
+++ b/scripts/post_migration_fixes/pmf_sup_level_20220308_in1182/supervision_level_log.sql
@@ -1,0 +1,79 @@
+CREATE SCHEMA IF NOT EXISTS pmf_sup_level_20220308_in1182;
+
+-- DROP TABLE IF EXISTS pmf_sup_level_20220308_in1182.supervision_level_log_audit;
+-- DROP TABLE IF EXISTS pmf_sup_level_20220308_in1182.supervision_level_log_inserts;
+
+SET datestyle = "ISO, DMY";
+
+SELECT sll.*
+INTO pmf_sup_level_20220308_in1182.supervision_level_log_audit
+FROM supervision_level_log sll
+INNER JOIN cases c ON c.id = sll.order_id
+INNER JOIN persons p ON p.id = c.client_id
+WHERE p.clientsource = 'CASRECMIGRATION';
+
+WITH casrec_supervision_levels AS (
+    SELECT a.*, ROW_NUMBER() OVER (ORDER BY a."Order No", a."Start Date"::date) AS row_number
+    FROM (
+        SELECT DISTINCT ON ("Order No", "Start Date"::date)
+               "Order No",
+               "Start Date",
+               "Date Create",
+               "Asmt Lvl"
+        FROM casrec_csv.risk_assessment
+        WHERE "Start Date" <> ''
+          AND "Asmt Lvl" <> ''
+        ORDER BY "Order No", "Start Date"::date, COALESCE(NULLIF("Date Create", ''), "Start Date")::date DESC
+    ) a
+)
+SELECT c.id as order_id,
+       csl1."Start Date"::date as appliesfrom,
+       COALESCE(NULLIF(csl1."Date Create", ''), csl1."Start Date")::date as createddate,
+       CASE WHEN csl1."Asmt Lvl" = '3' THEN 'MINIMAL' ELSE 'GENERAL' END as supervisionlevel,
+       CASE WHEN csl1."Asmt Lvl" = '3' THEN 'LOW' ELSE 'HIGH' END as assetlevel,
+       'Migrated from Casrec' as notes
+INTO pmf_sup_level_20220308_in1182.supervision_level_log_inserts
+FROM casrec_supervision_levels csl1
+LEFT JOIN casrec_supervision_levels csl2
+    ON csl1.row_number = csl2.row_number + 1 AND csl1."Order No" = csl2."Order No"
+INNER JOIN casrec_mapping.cases cmc ON cmc."Order No" = csl1."Order No"
+INNER JOIN cases c ON c.id = cmc.sirius_id
+WHERE csl1."Asmt Lvl" <> csl2."Asmt Lvl" or csl2."Asmt Lvl" is null
+ORDER BY csl1.row_number;
+
+BEGIN;
+    DELETE FROM supervision_level_log sll
+    USING pmf_sup_level_20220308_in1182.supervision_level_log_audit slla
+    WHERE sll.id = slla.id;
+
+    INSERT INTO supervision_level_log (id, order_id, appliesfrom, createddate, supervisionlevel, notes, assetlevel)
+    SELECT nextval('supervision_level_log_id_seq'), slli.order_id, slli.appliesfrom, slli.createddate, slli.supervisionlevel, slli.notes, slli.assetlevel
+    FROM pmf_sup_level_20220308_in1182.supervision_level_log_inserts slli;
+-- Run if counts incorrect
+ROLLBACK;
+-- Run if counts correct
+COMMIT;
+
+-- Validation script (should be 0)
+WITH sirius_side AS (
+    SELECT sll.order_id, sll.appliesfrom, sll.createddate, sll.supervisionlevel, sll.notes, sll.assetlevel
+    FROM supervision_level_log sll
+    INNER JOIN cases c ON c.id = sll.order_id
+    INNER JOIN persons p ON p.id = c.client_id
+    WHERE p.clientsource = 'CASRECMIGRATION'
+),
+casrec_side AS (
+    SELECT order_id, appliesfrom, createddate, supervisionlevel, notes, assetlevel
+    FROM pmf_sup_level_20220308_in1182.supervision_level_log_inserts
+)
+SELECT 'not in Sirius' as validation, * FROM (
+    SELECT * FROM casrec_side
+    EXCEPT
+    SELECT * FROM sirius_side
+) validation1
+UNION
+SELECT 'not in Casrec' as validation, * FROM (
+    SELECT * FROM sirius_side
+    EXCEPT
+    SELECT * FROM casrec_side
+) validation2;


### PR DESCRIPTION
## Purpose

Initially we only migrated the latest supervision levels.

The purpose of this is to bring accross all suppervision level changes, as they are required for billing purposes.

## Approach

Delete all supervision level logs that were migrated initially, as they have an incorrect appliesfrom date.

Order risk assessments chronologically (by "Start Date") for each case and filter out any that didn't change the supervision level. Where two or more risk assessments have the same "Start Date", we use the one with the latest "Date Create" date.

There is 1 risk assessment in the DB that doesn't have a "Date Create", so we default that to "Start Date".

## Learning

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
