### PR TITLE
IN-1119 PA/PRO deputies set persons.deputysubtype

### DIFF
--- a/migration_steps/shared/validation_mapping.json
+++ b/migration_steps/shared/validation_mapping.json
@@ -673,7 +673,6 @@
         "exclude": [
             "caserecnumber",
             "dateofdeath",
-            "middlenames",
             "uid",
             "deputycasrecid",
             "updateddate"
@@ -693,17 +692,18 @@
             "from_table": "deputyship",
             "transform": {
                 "deputynumber": "CAST(NULLIF(TRIM({casrec_schema}.deputy.\"Deputy No\"), '') AS integer)",
-                "organisationname": "CASE WHEN {casrec_schema}.deputy_type_lookup(TRIM({casrec_schema}.deputy.\"Dep Type\")) = 'PA' THEN transf_capitalise_first_letter(TRIM({casrec_schema}.deputy.\"Dep Surname\")) ELSE NULL END",
-                "deputysubtype": "CASE WHEN {casrec_schema}.deputy_type_lookup(TRIM({casrec_schema}.deputy.\"Dep Type\")) = 'PA' THEN 'ORGANISATION' WHEN {casrec_schema}.deputy_type_lookup(TRIM({casrec_schema}.deputy.\"Dep Type\")) = 'LAY' THEN 'PERSON' ELSE NULL END",
-                "surname": "CASE WHEN {casrec_schema}.deputy_type_lookup(TRIM({casrec_schema}.deputy.\"Dep Type\")) = 'PA' THEN NULL ELSE transf_capitalise_first_letter(NULLIF(TRIM({casrec_schema}.deputy.\"Dep Surname\"), '')) END",
-                "salutation": "CASE WHEN {casrec_schema}.deputy_type_lookup(TRIM({casrec_schema}.deputy.\"Dep Type\")) = 'PA' THEN NULL ELSE {casrec_schema}.title_codes_lookup(TRIM({casrec_schema}.deputy.\"Title\")) END",
-                "firstname": "CASE WHEN {casrec_schema}.deputy_type_lookup(TRIM({casrec_schema}.deputy.\"Dep Type\")) = 'PA' THEN NULL ELSE transf_first_word(NULLIF(TRIM({casrec_schema}.deputy.\"Dep Forename\"), '')) END",
-                "othernames": "NULLIF(TRIM(transf_last_words(NULLIF(TRIM({casrec_schema}.deputy.\"Dep Forename\"), ''))), '')"
+                "organisationname": "ddpc.organisationname",
+                "deputysubtype": "ddpc.deputysubtype",
+                "surname": "ddpc.surname",
+                "salutation": "ddpc.salutation",
+                "firstname": "ddpc.firstname",
+                "othernames": "ddpc.othernames"
             },
             "joins": [
                 "LEFT JOIN {casrec_schema}.order ON {casrec_schema}.order.\"Order No\" = {casrec_schema}.deputyship.\"Order No\"",
                 "LEFT JOIN {casrec_schema}.deputy ON {casrec_schema}.deputyship.\"Deputy No\" = {casrec_schema}.deputy.\"Deputy No\"",
-                "LEFT JOIN {casrec_schema}.pat ON {casrec_schema}.pat.\"Case\" = {casrec_schema}.order.\"Case\""
+                "LEFT JOIN {casrec_schema}.pat ON {casrec_schema}.pat.\"Case\" = {casrec_schema}.order.\"Case\"",
+                "LEFT JOIN {casrec_schema}.derive_deputy_persons_columns({casrec_schema}.deputyship.\"Order No\", {casrec_schema}.deputy.\"Deputy No\", {casrec_schema}.deputy.\"Dep Type\", {casrec_schema}.deputy.\"Title\", {casrec_schema}.deputy.\"Dep Forename\", {casrec_schema}.deputy.\"Dep Surname\") AS ddpc ON {casrec_schema}.deputyship.\"Deputy No\" = ddpc.deputynumber AND {casrec_schema}.deputyship.\"Order No\" = ddpc.ordernumber"
             ],
             "exception_table_join": "LEFT JOIN {casrec_schema}.exceptions_deputy_persons exc_table\n    ON exc_table.caserecnumber = pat.\"Case\"\n    AND exc_table.casesubtype = {casrec_schema}.order_type_lookup({casrec_schema}.order.\"Ord Type\")\n    AND exc_table.orderdate = {casrec_schema}.order.\"Made Date\"",
             "where_clauses": [

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/deputymapper.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/deputymapper.py
@@ -1,0 +1,59 @@
+import pandas as pd
+
+
+def map_deputy_subtype(row: pd.Series) -> pd.Series:
+    """
+    Map deputy subtype (and associated name fields) depending
+    on whether this is a Lay, PA or PRO deputy.
+
+    See IN-1118 and IN-1119.
+
+    :param row: Deputy row mapped from casrec to Sirius. The Sirius
+        columns are used to complete the mapping (rather than the
+        casrec ones).
+
+        Expected columns in row are:
+        - deputytype
+        - firstname
+        - surname
+
+        The following columns are touched, depending on whether the
+        row is for a LAY or PA/PRO deputy, and depending
+        on which input columns are set (or not):
+        - organisationname
+        - deputysubtype
+        - surname
+        - saluation
+        - firstname
+        - othernames
+    """
+    row["organisationname"] = None
+    row["deputysubtype"] = None
+
+    is_pa_or_pro_deputy = row["deputytype"] in ("PA", "PRO")
+    is_lay_deputy = row["deputytype"] == "LAY"
+
+    has_firstname = row["firstname"] not in (None, "")
+    has_surname = row["surname"] not in (None, "")
+
+    # these rules are derived from IN-1119
+    is_organisation = is_pa_or_pro_deputy and not has_firstname
+    is_person = is_lay_deputy or (is_pa_or_pro_deputy and has_firstname and has_surname)
+
+    # deputytype is set from the deputy_type_lookup
+    # in the Deputy spreadsheet
+    if is_organisation:
+        row["deputysubtype"] = "ORGANISATION"
+
+        # Ordering is important for next two lines
+        row["organisationname"] = row["surname"]
+        row["surname"] = None
+
+        row["salutation"] = None
+        row["firstname"] = None
+        row["othernames"] = None
+
+    elif is_person:
+        row["deputysubtype"] = "PERSON"
+
+    return row

--- a/migration_steps/transform_casrec/transform/app/entities/deputies/persons.py
+++ b/migration_steps/transform_casrec/transform/app/entities/deputies/persons.py
@@ -4,35 +4,11 @@ import pandas as pd
 from utilities.basic_data_table import get_basic_data_table
 
 from custom_errors import EmptyDataFrame
+from entities.deputies.deputymapper import map_deputy_subtype
 from helpers import get_mapping_dict, get_table_def
 from transform_data.apply_datatypes import apply_datatypes
 
 log = logging.getLogger("root")
-
-
-def _set_columns_for_deputy_type(row: pd.Series) -> pd.Series:
-    row["organisationname"] = None
-    row["deputysubtype"] = None
-
-    # deputytype is set from the deputy_type_lookup
-    # in the Deputy spreadsheet
-    if row["deputytype"] == "PA":
-        row["deputysubtype"] = "ORGANISATION"
-
-        # Clear name columns for public authorities
-
-        # Ordering is important for next two lines
-        row["organisationname"] = row["surname"]
-        row["surname"] = None
-
-        row["salutation"] = None
-        row["firstname"] = None
-        row["middlenames"] = None
-
-    elif row["deputytype"] == "LAY":
-        row["deputysubtype"] = "PERSON"
-
-    return row
 
 
 def insert_persons_deputies(db_config, target_db, mapping_file):
@@ -66,8 +42,8 @@ def insert_persons_deputies(db_config, target_db, mapping_file):
             persons_df["deputycasrecid"] = persons_df["casrec_row_id"]
 
             # Apply additional transforms manually which depend
-            # on whether this is a Lay or PA deputy (see IN-1118)
-            persons_df = persons_df.apply(_set_columns_for_deputy_type, axis=1)
+            # on whether this is a Lay or PA deputy (see IN-1118 and IN-1119)
+            persons_df = persons_df.apply(map_deputy_subtype, axis=1)
 
             target_db.insert_data(
                 table_name=table_definition["destination_table_name"],

--- a/migration_steps/transform_casrec/transform/transform_tests/transform_data_tests/entities/deputies/test_deputy_mapper.py
+++ b/migration_steps/transform_casrec/transform/transform_tests/transform_data_tests/entities/deputies/test_deputy_mapper.py
@@ -1,0 +1,141 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from entities.deputies.deputymapper import map_deputy_subtype
+
+
+def test_map_deputy_subtype_with_examples():
+    # deputytype, firstname and surname are used to set the other columns
+    test_df = pd.DataFrame(
+        [
+            {
+                # Person: Lay
+                "deputytype": "LAY",
+                "firstname": "Vone",
+                "surname": "Spork",
+                "salutation": "Mr",
+                "middlenames": "Ventafin",
+                "note": "Lay deputy => person",
+            },
+            {
+                # Person: PA with firstname and surname
+                "deputytype": "PA",
+                "firstname": "Biffo",
+                "surname": "Andalusia",
+                "salutation": "Ms",
+                "middlenames": "Peregrin",
+                "note": "PA deputy with firstname and surname => person",
+            },
+            {
+                # Person: PRO with firstname and surname
+                "deputytype": "PRO",
+                "firstname": "Majelian",
+                "surname": "DeCroscifor",
+                "salutation": "Dr",
+                "middlenames": "Subantafax",
+                "note": "PRO deputy with firstname and surname => person",
+            },
+            {
+                # Organisation: PA without firstname
+                "deputytype": "PA",
+                "firstname": "",
+                "surname": "Baragron Corp",
+                "salutation": "Reverend",
+                "middlenames": "Bargastofon",
+                "note": "PA deputy without firstname => organisation",
+            },
+            {
+                "deputytype": "PRO",
+                "firstname": None,
+                "surname": "Big Company",
+                "salutation": "Miss",
+                "middlenames": "Velocipede",
+                "note": "PRO deputy without firstname => organisation",
+            },
+            {
+                "deputytype": "PRO",
+                "firstname": None,
+                "surname": None,
+                "salutation": "Professor",
+                "middlenames": "Mandragorian",
+                "note": "PRO deputy with no firstname or surname => organisation",
+            },
+        ]
+    )
+
+    expected = pd.DataFrame(
+        [
+            {
+                "deputytype": "LAY",
+                "firstname": "Vone",
+                "surname": "Spork",
+                "salutation": "Mr",
+                "middlenames": "Ventafin",
+                "organisationname": None,
+                "deputysubtype": "PERSON",
+            },
+            {
+                "deputytype": "PA",
+                "firstname": "Biffo",
+                "surname": "Andalusia",
+                "salutation": "Ms",
+                "middlenames": "Peregrin",
+                "organisationname": None,
+                "deputysubtype": "PERSON",
+            },
+            {
+                "deputytype": "PRO",
+                "firstname": "Majelian",
+                "surname": "DeCroscifor",
+                "salutation": "Dr",
+                "middlenames": "Subantafax",
+                "organisationname": None,
+                "deputysubtype": "PERSON",
+            },
+            {
+                "deputytype": "PA",
+                "firstname": None,
+                "surname": None,
+                "salutation": None,
+                "middlenames": None,
+                "organisationname": "Baragron Corp",
+                "deputysubtype": "ORGANISATION",
+            },
+            {
+                "deputytype": "PRO",
+                "firstname": None,
+                "surname": None,
+                "salutation": None,
+                "middlenames": None,
+                "organisationname": "Big Company",
+                "deputysubtype": "ORGANISATION",
+            },
+            {
+                "deputytype": "PRO",
+                "firstname": None,
+                "surname": None,
+                "salutation": None,
+                "middlenames": None,
+                "organisationname": None,
+                "deputysubtype": "ORGANISATION",
+            },
+        ]
+    )
+
+    actual = test_df.apply(map_deputy_subtype, axis=1)
+
+    assert_frame_equal(expected, actual.drop(columns=["note"]))
+
+    # print examples for verification with UAT
+    examples = test_df.join(actual, how="inner", lsuffix=" (in)", rsuffix=" (out)")
+    examples = examples.drop(columns=["note (out)", "deputytype (out)"]).rename(
+        columns={
+            "note (in)": "Note",
+            "organisationname": "organisationname (out)",
+            "deputysubtype": "deputysubtype (out)",
+        }
+    )
+    columns = examples.columns.tolist()
+    columns.remove("Note")
+    columns.append("Note")
+    print("\n" + examples[columns].to_markdown())


### PR DESCRIPTION
## Purpose

[IN-1119](https://opgtransform.atlassian.net/browse/IN-1119)

## Approach

Set deputysubtype based on the deputy code and presence of surname. Then set organisationname and clear other name fields for organisations.

## Learning

n/a

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
