### PR TITLE
IN-1228 add the sirius side pmf into our script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,8 +240,13 @@ workflows:
           tf_workspace: preproduction
           runner_command: migration-light-touch-api-tests
       - run_task:
-          name: migration - post migration fixes preproduction
+          name: migration - post migration sirius side fixes preproduction
           requires: [migration - light touch api tests preproduction]
+          tf_workspace: preproduction
+          runner_command: post-casrec-migration-script-update-report-status
+      - run_task:
+          name: migration - post migration fixes preproduction
+          requires: [migration - post migration sirius side fixes preproduction]
           tf_workspace: preproduction
           runner_command: migration-post-migration-fixes
       - scale-services:
@@ -363,8 +368,13 @@ workflows:
           tf_workspace: preqa
           runner_command: migration-validation
       - run_task:
-          name: migration - post migration fixes preqa
+          name: migration - post migration sirius side fixes preqa
           requires: [migration - validation preqa]
+          tf_workspace: preqa
+          runner_command: post-casrec-migration-script-update-report-status
+      - run_task:
+          name: migration - post migration fixes preqa
+          requires: [migration - post migration sirius side fixes preqa]
           tf_workspace: preqa
           runner_command: migration-post-migration-fixes
       - scale-services:
@@ -462,8 +472,13 @@ workflows:
           tf_workspace: qa
           runner_command: migration-validation
       - run_task:
-          name: migration - post migration fixes qa
+          name: migration - post migration sirius side fixes qa
           requires: [migration - validation qa]
+          tf_workspace: qa
+          runner_command: post-casrec-migration-script-update-report-status
+      - run_task:
+          name: migration - post migration fixes qa
+          requires: [migration - post migration sirius side fixes qa]
           tf_workspace: qa
           runner_command: migration-post-migration-fixes
       - scale-services:
@@ -600,8 +615,13 @@ workflows:
           tf_workspace: production
           runner_command: migration-light-touch-api-tests
       - run_task:
-          name: migration - post migration fixes production
+          name: migration - post migration sirius side fixes production
           requires: [migration - light touch api tests production]
+          tf_workspace: production
+          runner_command: post-casrec-migration-script-update-report-status
+      - run_task:
+          name: migration - post migration fixes production
+          requires: [migration - post migration sirius side fixes production]
           tf_workspace: production
           runner_command: migration-post-migration-fixes
       - run_elasticsearch_reset:
@@ -726,8 +746,13 @@ workflows:
           tf_workspace: rehearsal
           runner_command: migration-light-touch-api-tests
       - run_task:
-          name: migration - post migration fixes rehearsal
+          name: migration - post migration sirius side fixes rehearsal
           requires: [migration - light touch api tests rehearsal]
+          tf_workspace: rehearsal
+          runner_command: post-casrec-migration-script-update-report-status
+      - run_task:
+          name: migration - post migration fixes rehearsal
+          requires: [migration - post migration sirius side fixes rehearsal]
           tf_workspace: rehearsal
           runner_command: migration-post-migration-fixes
       - run_elasticsearch_reset:
@@ -858,8 +883,14 @@ workflows:
           runner_command: migration-response-api-tests
           filters: {branches:{only:[main]}}
       - run_task:
-          name: migration - post migration fixes preproduction
+          name: migration - post migration sirius side fixes preproduction
           requires: [migration - response api tests preproduction]
+          tf_workspace: preproduction
+          runner_command: post-casrec-migration-script-update-report-status
+          filters: {branches:{only:[main]}}
+      - run_task:
+          name: migration - post migration fixes preproduction
+          requires: [migration - post migration sirius side fixes preproduction]
           tf_workspace: preproduction
           runner_command: migration-post-migration-fixes
       - scale-services:
@@ -1483,6 +1514,9 @@ jobs:
       - run:
           name: Run light touch api tests task
           command: ecs-runner -task migration-light-touch-api-tests -timeout << parameters.timeout >>
+      - run:
+          name: Run sirius side post migration fixes
+          command: ecs-runner -task post-casrec-migration-script-update-report-status -timeout << parameters.timeout >>
       - run:
           name: Run post migration fixes
           command: ecs-runner -task migration-post-migration-fixes -timeout << parameters.timeout >>

--- a/migration_steps/initialise_environments/delete_existing_data/app.py
+++ b/migration_steps/initialise_environments/delete_existing_data/app.py
@@ -80,15 +80,15 @@ def pre_deletion_flag_alignment_check():
     sql = f"""
          SELECT caserecnumber
          FROM {db_config["target_schema"]}.persons
-         WHERE clientsource = 'CLIENT-PILOT-ONE';
+         WHERE caseactorgroup = 'CLIENT-PILOT-ONE';
     """
     target_response = target_db_engine.execute(sql)
     sirius_cases = [r._mapping["caserecnumber"] for r in target_response]
 
     sql = f"""
-             SELECT "Case" as caserecnumber
-             FROM {db_config["source_schema"]}.pat
-             WHERE "Sirius" = 'Y';
+         SELECT "Case" as caserecnumber
+         FROM {db_config["source_schema"]}.pat
+         WHERE "Sirius" = 'Y';
     """
     source_response = source_db_engine.execute(sql)
     casrec_cases = [r._mapping["caserecnumber"] for r in source_response]

--- a/terraform/environment/tasks.toml
+++ b/terraform/environment/tasks.toml
@@ -462,6 +462,22 @@
           }
         },
         "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/elasticsearch-reindex-${cluster}"
+      },
+      "post-casrec-migration-script-update-report-status": {
+        "Cluster": "${cluster}",
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "SecurityGroups": [
+              "${sec-group-api}",
+              "${sec-group-es}"
+            ],
+            "Subnets": [
+              "${subnets}"
+            ]
+          }
+        },
+        "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/post-casrec-migration-script-update-report-status-${cluster}"
       }
     }
   }


### PR DESCRIPTION
## Purpose

It has been pointed out that this sirus side PMF needs to run BEFORE all our PMF scripts and was not currently part of the pipeline! As such we need to add it before our other automated PMFs

## Approach

Add to the pipeline before running our standard automated pmfs

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
