### PR TITLE
IN-1219 fix ordering of death statuses

### DIFF
--- a/migration_steps/integration/business_rules/app/rules/client_statuses.py
+++ b/migration_steps/integration/business_rules/app/rules/client_statuses.py
@@ -126,8 +126,8 @@ def update_client_statuses_table(db_config, cursor, conn):
         UPDATE {db_config["target_schema"]}.{client_status_lkp_table}
         SET final_client_status =
         CASE
-            WHEN death_notified_status = 'DEATH_NOTIFIED' THEN 'DEATH_NOTIFIED'
             WHEN death_proof_status = 'DEATH_CONFIRMED' THEN 'DEATH_CONFIRMED'
+            WHEN death_notified_status = 'DEATH_NOTIFIED' THEN 'DEATH_NOTIFIED'
             WHEN has_active_status = 'ACTIVE' THEN 'ACTIVE'
             WHEN latest_status = 'OPEN' THEN 'OPEN'
             WHEN closed_dup_status = 'CLOSED'

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/13_pmf_assignees_in1221/persons.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/13_pmf_assignees_in1221/persons.sql
@@ -74,7 +74,7 @@ FROM
     pat."Corref" as corref, ctt.team, a.id as ass_id, {casrec_schema}.assignee_lookup(pdo."DPfcw") as pro_dep_owner_id
     FROM persons per
     INNER JOIN {casrec_schema}.pat pat on pat."Case" = per.caserecnumber
-    INNER JOIN {casrec_mapping}.corref_to_team ctt on pat."Corref" = ctt.corref
+    LEFT JOIN {casrec_mapping}.corref_to_team ctt on pat."Corref" = ctt.corref
     LEFT JOIN assignees a on a.name = ctt.team
     LEFT JOIN pro_dep_owner pdo on pdo."Case" = pat."Case"
     WHERE per.supervisioncaseowner_id = 2657


### PR DESCRIPTION
## Purpose

Somehow had the ordering of death notified and death confirmed the wrong way round.  Also think that inner join for assignees is a bit too restrictive and would stop pro assignees that have a deputy owner entry from getting updated.

## Approach

NA

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
