### PR TITLE
IN-1234 get rid of unneeded rollbacks for pmfs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1005,7 +1005,7 @@ orbs:
     executors:
       python:
         docker:
-          - image: cimg/python:3.9.5
+          - image: cimg/python:3.9.12
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN


### PR DESCRIPTION
## Purpose

Rollbacks were added where validation mismatched but this is actually super unhelpful as all the validation mismatches are out by a few cases and it's hard to work out what they are and it's holding up testing. Better to remove the rollbacks and then look into validation issue and let UAT get on with testing.

## Approach

Removed rollbacks
Removed a bit of Dimitars script that he said was now not needed.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
