### PR TITLE
IN-1242 pmf for annual report logs resubmit date

### DIFF
--- a/migration_steps/validation/post_migration_fixes/app/app.py
+++ b/migration_steps/validation/post_migration_fixes/app/app.py
@@ -126,6 +126,21 @@ def copy_mapping_tables(casrec_mapping_schema):
         to_table=f"{casrec_mapping_schema}.annual_report_logs",
     )
 
+    # Mapping from Sirius annual_report_logs ID to casrec_row_id
+    # \copy (SELECT casrec_row_id, id FROM integration.annual_report_logs where casrec_table_name = 'account')
+    # To 'arl.csv' With CSV DELIMITER ',' HEADER
+    # \copy casrec_mapping_p2.annual_report_logs_casrec_id(id, casrec_row_id) FROM 'arl.csv' DELIMITER ',' CSV HEADER
+    _copy(
+        create_sql=f"""
+        CREATE TABLE IF NOT EXISTS {casrec_mapping_schema}.annual_report_logs_casrec_id (
+            id int PRIMARY KEY,
+            casrec_row_id varchar
+        )
+        """,
+        from_sql="SELECT casrec_row_id, id FROM integration.annual_report_logs where casrec_table_name = 'account'",
+        to_table=f"{casrec_mapping_schema}.annual_report_logs_casrec_id",
+    )
+
 
 def delete_schema(schema_name, cursor, conn):
     sql = f"""

--- a/migration_steps/validation/post_migration_fixes/app/app.py
+++ b/migration_steps/validation/post_migration_fixes/app/app.py
@@ -126,21 +126,6 @@ def copy_mapping_tables(casrec_mapping_schema):
         to_table=f"{casrec_mapping_schema}.annual_report_logs",
     )
 
-    # Mapping from Sirius annual_report_logs ID to casrec_row_id
-    # \copy (SELECT casrec_row_id, id FROM integration.annual_report_logs where casrec_table_name = 'account')
-    # To 'arl.csv' With CSV DELIMITER ',' HEADER
-    # \copy casrec_mapping_p2.annual_report_logs_casrec_id(id, casrec_row_id) FROM 'arl.csv' DELIMITER ',' CSV HEADER
-    _copy(
-        create_sql=f"""
-        CREATE TABLE IF NOT EXISTS {casrec_mapping_schema}.annual_report_logs_casrec_id (
-            id int PRIMARY KEY,
-            casrec_row_id varchar
-        )
-        """,
-        from_sql="SELECT casrec_row_id, id FROM integration.annual_report_logs where casrec_table_name = 'account'",
-        to_table=f"{casrec_mapping_schema}.annual_report_logs_casrec_id",
-    )
-
 
 def delete_schema(schema_name, cursor, conn):
     sql = f"""

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/14_pmf_reports_in1242/annual_report_logs.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/14_pmf_reports_in1242/annual_report_logs.sql
@@ -1,0 +1,79 @@
+--Purpose: update where users have entered Further dates but have not added the equivalent row Rcvd Date
+--and have instead added review dates which maps to resubmitteddate on sirius side
+--@setup_tag
+CREATE SCHEMA IF NOT EXISTS {pmf_schema};
+
+SELECT
+"Case",
+"Further Date1",
+"Further Date2",
+"Further Date3",
+"Further Date4",
+"Further Date6",
+"Further Date6.1",
+"Rcvd Date1",
+"Rcvd Date2",
+"Rcvd Date3",
+"Rcvd Date4",
+"Rcvd Date5",
+"Rcvd Date6",
+arld.id as arld_id,
+cast("Review Date" as date) as expected_value
+INTO {pmf_schema}.annual_report_lodging_details_updates
+FROM
+(
+    SELECT
+    "Case",
+    "casrec_row_id",
+    CASE
+    WHEN "Further Date1" != '' and "Rcvd Date1" = ''
+    OR "Further Date2" != '' and "Rcvd Date2" = ''
+    OR "Further Date3" != '' and "Rcvd Date3" = ''
+    OR "Further Date4" != '' and "Rcvd Date4" = ''
+    OR "Further Date6" != '' and "Rcvd Date5" = ''
+    OR "Further Date6.1" != '' and "Rcvd Date6" = ''
+    THEN 1 ELSE 0 END as mismatch,
+    "Further Date1",
+    "Further Date2",
+    "Further Date3",
+    "Further Date4",
+    "Further Date6",
+    "Further Date6.1",
+    "Rcvd Date1",
+    "Rcvd Date2",
+    "Rcvd Date3",
+    "Rcvd Date4",
+    "Rcvd Date5",
+    "Rcvd Date6",
+    "Review Date"
+    from {casrec_schema}.account
+    where "Review Date" != ''
+) as account_records
+INNER JOIN {casrec_mapping}.annual_report_logs_casrec_id map
+ON cast(map.casrec_row_id as int) = cast(account_records."casrec_row_id" as int)
+INNER JOIN annual_report_logs arl on arl.id = map.id
+INNER JOIN annual_report_lodging_details arld on arld.annual_report_log_id = arl.id
+INNER JOIN persons p on p.id = arl.client_id
+WHERE account_records.mismatch = 1
+AND p.clientsource = '{client_source}';
+
+--@audit_tag
+SELECT arld.*
+INTO {pmf_schema}.annual_report_log_audit
+FROM annual_report_lodging_details arld
+INNER JOIN {pmf_schema}.annual_report_lodging_details_updates u ON arld.id = u.arld_id;
+
+--@update_tag
+UPDATE annual_report_lodging_details arld SET resubmitteddate = u.expected_value
+FROM {pmf_schema}.annual_report_lodging_details_updates u
+WHERE u.arld_id = arld.id;
+
+--@validate_tag
+SELECT arld_id, cast(expected_value as date)
+FROM {pmf_schema}.annual_report_lodging_details_updates
+EXCEPT
+SELECT arld.id, cast(arld.resubmitteddate as date)
+FROM persons p
+INNER JOIN annual_report_logs arl on p.id = arl.client_id
+INNER JOIN annual_report_lodging_details arld on arld.annual_report_log_id = arl.id;
+


### PR DESCRIPTION
## Purpose

Users were adding further info dates for which rcvd dates were expected. In some cases though instead of adding received date, they just added it in the review date column

## Approach

Where there is a further date with no matching rcvd date and the review date has been set then add the review date as resubmit date.

Tried with the 'sirius' type logic first but it was bringing back mostly rows for which there was no further date at all. As such we have had to do a join with the original data to get the correct info.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
