### PR TITLE
PM17 IN-1243 Set reporting start date to end date-365

### DIFF
--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/15_pmf_reports_in1243/annual_report_logs.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/15_pmf_reports_in1243/annual_report_logs.sql
@@ -1,0 +1,46 @@
+--Purpose: update report logs - set pending reports with date range > 1 year back to 365 days
+--@setup_tag
+CREATE SCHEMA IF NOT EXISTS {pmf_schema};
+
+SELECT *
+INTO {pmf_schema}.arl_updates
+FROM (
+    SELECT
+        p.caserecnumber,
+        arl.id AS arl_id,
+        reportingperiodenddate,
+        (reportingperiodenddate - INTERVAL '365 DAY')::DATE AS startdate_expected,
+        (reportingperiodenddate::DATE - (reportingperiodenddate - INTERVAL '365 DAY')::DATE) diff_days_expected,
+        reportingperiodstartdate AS startdate_actual,
+        (reportingperiodenddate::DATE - reportingperiodstartdate::DATE) diff_days_actual
+    FROM annual_report_logs arl
+    LEFT JOIN persons p
+    ON p.id = arl.client_id
+    WHERE p.clientsource = '{client_source}'
+) to_update
+WHERE to_update.diff_days_actual > 365
+ORDER BY to_update.diff_days_actual DESC;
+
+--@audit_tag
+SELECT arl.*
+INTO {pmf_schema}.arl_audit
+FROM annual_report_logs arl
+INNER JOIN {pmf_schema}.arl_updates u ON arl.id = u.arl_id;
+
+--@update_tag
+UPDATE annual_report_logs arl SET reportingperiodstartdate = u.startdate_expected
+FROM {pmf_schema}.arl_updates u
+WHERE u.arl_id = arl.id;
+
+--@validate_tag
+SELECT
+    arl_id,
+    startdate_expected
+FROM {pmf_schema}.arl_updates u
+EXCEPT
+SELECT
+       arl.id,
+       arl.reportingperiodstartdate
+FROM annual_report_logs arl
+INNER JOIN {pmf_schema}.arl_audit a
+    ON a.id = arl.id;


### PR DESCRIPTION
## Purpose

Where the interval between an annual_report_log's reportingstartdate and reportingenddate is greater than 365 days, adjust the start date to make it 365

## Approach

Kept it simple with the INTERVAL function

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
