### PR TITLE
IN-1250 PM18 add missing order_deps

### DIFF
--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/18_pmf_order_deputy_in1250/01_insert_missing_order_deputy.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/18_pmf_order_deputy_in1250/01_insert_missing_order_deputy.sql
@@ -51,6 +51,7 @@ FROM (
 
 -- order_deputies to insert
 SELECT
+    nextval('order_deputy_id_seq') as order_deputy_id,
     mo.person_id,
     mo.order_id,
     od.deputy_id,
@@ -83,7 +84,7 @@ INSERT INTO order_deputy (
 SELECT
     order_id,
     deputy_id,
-    nextval('order_deputy_id_seq'),
+    order_deputy_id,
     deputytype,
     statusoncase,
     relationshiptoclient,

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/18_pmf_order_deputy_in1250/01_insert_missing_order_deputy.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/18_pmf_order_deputy_in1250/01_insert_missing_order_deputy.sql
@@ -1,0 +1,98 @@
+--Purpose: Some hybrid cases don't have any deputies linked to one of the two active orders
+-- this script identifies those and copys the order_deputy link(s) from one order onto the other.
+--@setup_tag
+CREATE SCHEMA IF NOT EXISTS {pmf_schema};
+
+-- The setup SQL
+-- dual_orders, save for audit
+SELECT
+       p.id AS person_id,
+       c1.id AS order_id_hw,
+       c2.id AS order_id_pfa
+INTO {pmf_schema}.hybrd_cases
+FROM persons p
+INNER JOIN cases c1 ON c1.client_id = p.id
+INNER JOIN cases c2 ON c2.client_id = p.id
+WHERE c1.casesubtype = 'hw'
+AND c2.casesubtype = 'pfa'
+AND c1.orderstatus = 'ACTIVE'
+AND c2.orderstatus = 'ACTIVE'
+AND p.clientsource LIKE 'CASRECMIGRATION%';
+--1674
+
+-- orders missing an order_deputy, save for audit
+SELECT *
+INTO {pmf_schema}.hybrd_cases_missing_orderdeputy
+FROM (
+    SELECT DISTINCT
+        hyb.person_id AS person_id,
+        od_pfa.id AS orderdeputy_id,
+        hyb.order_id_hw AS order_id,
+        od_pfa.id AS od_pfa_id,
+        od_hw.id AS od_hw_id
+    FROM {pmf_schema}.hybrd_cases hyb
+    LEFT JOIN order_deputy od_hw ON od_hw.order_id = hyb.order_id_hw
+    LEFT JOIN order_deputy od_pfa ON od_pfa.order_id = hyb.order_id_pfa
+    WHERE od_hw.id IS NULL AND od_pfa.id IS NOT NULL
+    UNION ALL
+    SELECT DISTINCT
+        hyb.person_id AS person_id,
+        od_hw.id AS orderdeputy_id,
+        hyb.order_id_pfa AS order_id,
+        od_pfa.id AS od_pfa_id,
+        od_hw.id AS od_hw_id
+    FROM {pmf_schema}.hybrd_cases hyb
+    LEFT JOIN order_deputy od_hw ON od_hw.order_id = hyb.order_id_hw
+    LEFT JOIN order_deputy od_pfa ON od_pfa.order_id = hyb.order_id_pfa
+    WHERE od_pfa.id IS NULL
+      AND od_hw.id IS NOT NULL
+) missing_od;
+--2360
+
+-- order_deputies to insert
+SELECT
+    mo.person_id,
+    mo.order_id,
+    od.deputy_id,
+    od.deputytype,
+    od.statusoncase,
+    od.relationshiptoclient,
+    od.relationshipother,
+    od.maincorrespondent,
+    od.statusoncaseoverride,
+    od.statuschangedate,
+    od.statusnotes
+INTO {pmf_schema}.order_deputy_inserts
+FROM {pmf_schema}.hybrd_cases_missing_orderdeputy mo
+INNER JOIN order_deputy od ON id = mo.orderdeputy_id;
+
+--@update_tag
+INSERT INTO order_deputy (
+    order_id,
+    deputy_id,
+    id,
+    deputytype,
+    statusoncase,
+    relationshiptoclient,
+    relationshipother,
+    maincorrespondent,
+    statusoncaseoverride,
+    statuschangedate,
+    statusnotes
+)
+SELECT
+    order_id,
+    deputy_id,
+    nextval('order_deputy_id_seq'),
+    deputytype,
+    statusoncase,
+    relationshiptoclient,
+    relationshipother,
+    maincorrespondent,
+    statusoncaseoverride,
+    statuschangedate,
+    statusnotes
+FROM {pmf_schema}.order_deputy_inserts;
+
+-- Some checking SQL.. this isn't validation
+--@validate_tag

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/18_pmf_order_deputy_in1250/01_insert_missing_order_deputy.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/18_pmf_order_deputy_in1250/01_insert_missing_order_deputy.sql
@@ -97,3 +97,30 @@ FROM {pmf_schema}.order_deputy_inserts;
 
 -- Some checking SQL.. this isn't validation
 --@validate_tag
+SELECT
+    order_id,
+    deputy_id,
+    order_deputy_id,
+    deputytype,
+    statusoncase,
+    relationshiptoclient,
+    relationshipother,
+    maincorrespondent,
+    statusoncaseoverride,
+    statuschangedate,
+    statusnotes
+FROM {pmf_schema}.order_deputy_inserts
+EXCEPT
+SELECT
+    order_id,
+    deputy_id,
+    id,
+    deputytype,
+    statusoncase,
+    relationshiptoclient,
+    relationshipother,
+    maincorrespondent,
+    statusoncaseoverride,
+    statuschangedate,
+    statusnotes
+FROM order_deputy;


### PR DESCRIPTION
Some hybrid cases where missing an order_deputy for both active orders. This script identifies the missing order_deputys and copies the deputy info over from the ‘other’ case

## Purpose

_Briefly describe the purpose of the change, and/or link to the ticket for context_

## Approach

Kept the logic as-is from Jim's SQL script except:
* Save the 'dual order' (hybrid) cases as a table, in case we need to audit later
* Save the 'missing_orders' cases as a table, instead of an ephemeral 'WITH' subclause
* renamed quite a bit to make logic clearer (to me at least) the split between hw and pfa instead of using numbers
* order_deputy_ids were being confusingly named order_ids... fixed those

## Jim's original SQL from 19/04/22 printed below
`create schema pmf_blah;

-- The setup SQL
with dualOrders as (
    select p.id as p_id, c1.id as c1_id, c2.id as c2_id
    from persons p
    inner join cases c1 on c1.client_id = p.id
    inner join cases c2 on c2.client_id = p.id
    where
    c1.casesubtype = 'hw'
    and c2.casesubtype = 'pfa'
    and c1.orderstatus = 'ACTIVE'
    and c2.orderstatus = 'ACTIVE'
    and p.clientsource LIKE 'CASRECMIGRATION%'
), missing_orders as (
    select distinct
    dor.p_id as person_id,
    od2.id as order_id,
    dor.c1_id as case_id
    from dualOrders dor
    left join order_deputy od1 on od1.order_id = dor.c1_id
    left join order_deputy od2 on od2.order_id = dor.c2_id
    where
    od1.id is null and od2.id is not null
    union all
    select distinct
    dor.p_id as person_id,
    od1.id as order_id,
    dor.c2_id as case_id
    from dualOrders dor
    left join order_deputy od1 on od1.order_id = dor.c1_id
    left join order_deputy od2 on od2.order_id = dor.c2_id
    where
    od2.id is null and od1.id is not null
)
select
mo.person_id,
mo.case_id as order_id,
od.deputy_id,
od.deputytype,
od.statusoncase,
od.relationshiptoclient,
od.relationshipother,
od.maincorrespondent,
od.statusoncaseoverride,
od.statuschangedate,
od.statusnotes
into pmf_blah.order_deputy_inserts
from missing_orders mo
inner join order_deputy od on id = mo.order_id;

-- The insert SQL
INSERT INTO order_deputy (
    order_id,
    deputy_id,
    id,
    deputytype,
    statusoncase,
    relationshiptoclient,
    relationshipother,
    maincorrespondent,
    statusoncaseoverride,
    statuschangedate,
    statusnotes
)
select
order_id,
deputy_id,
nextval('order_deputy_id_seq'),
deputytype,
statusoncase,
relationshiptoclient,
relationshipother,
maincorrespondent,
statusoncaseoverride,
statuschangedate,
statusnotes
from pmf_blah.order_deputy_inserts;

-- Some checking SQL.. this isn't validation
select p.id,
c.id as case_id,
c.casesubtype as casesubtype,
od.id as order_dep_id,
od.*
from persons p
left join cases c on c.client_id = p.id
left join order_deputy od on od.order_id = c.id
where c.orderstatus = 'ACTIVE';`

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
