### PR TITLE
IN-1267 remove reports predating orders p3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1543,6 +1543,13 @@ jobs:
       - run:
           name: Reset Elasticsearch
           command: ecs-runner -task reset-elasticsearch7 -timeout 18000
+      - run:
+          name: Reset Elasticsearch
+          command: ecs-runner -task reindex-elasticsearch -timeout 18000
+          background: true
+      - run:
+          name: Wait to show start of reindex output before continuing
+          command: sleep 120
       - notififications/notify_env_vars
       - notififications/notify_if_fail
 

--- a/migrate.sh
+++ b/migrate.sh
@@ -112,6 +112,7 @@ then
   docker rm casrec_load_2 &>/dev/null || echo "casrec_load_2 does not exist. This is OK"
   docker rm casrec_load_3 &>/dev/null || echo "casrec_load_3 does not exist. This is OK"
   docker rm casrec_load_4 &>/dev/null || echo "casrec_load_4 does not exist. This is OK"
+  docker-compose ${COMPOSE_ARGS} build load_casrec
   docker-compose ${COMPOSE_ARGS} run --rm --name casrec_load_1 load_casrec python3 load_casrec/app/app.py -p "1" -t "4" >> docker_load.log &
   P1=$!
   docker-compose ${COMPOSE_ARGS} run --rm --name casrec_load_2 load_casrec python3 load_casrec/app/app.py -p "2" -t "4" >> docker_load.log &

--- a/migration_steps/transform_casrec/transform/app/entities/timeline/timeline_event.py
+++ b/migration_steps/transform_casrec/transform/app/entities/timeline/timeline_event.py
@@ -137,6 +137,14 @@ def insert_timeline_events(db_config, target_db, mapping_file, event_sub_type):
                 "c_forename", "c_forename_first", timeline_events_df
             )
 
+            if event_sub_type == "archive":
+                timeline_events_df["timestamp"] = timeline_events_df.apply(
+                    lambda row: datetime.strptime(
+                        row["c_away_date"], "%Y-%m-%d %H:%M:%S"
+                    ).strftime("%Y-%m-%dT00:00:00+00:00"),
+                    axis=1,
+                )
+
             # Make the JSON in event column
             timeline_events_df["event"] = timeline_events_df.apply(
                 lambda row: _generate_timeline_event_data(

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/24_pmf_reports_in1267/annual_report_logs.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/24_pmf_reports_in1267/annual_report_logs.sql
@@ -1,0 +1,45 @@
+--Purpose: Remove reports on P3 deputies that are prior to first order date as they were entered erroneously
+--@setup_tag
+CREATE SCHEMA IF NOT EXISTS {pmf_schema};
+
+WITH earliest_order as
+(select distinct on (p.caserecnumber) p.caserecnumber, c.orderdate
+from persons p
+inner join cases c on c.client_id = p.id
+where p.clientsource = 'CASRECMIGRATION_P3' --Only run for this phase
+and p.type = 'actor_client'
+order by p.caserecnumber, c.orderdate asc)
+select p.caserecnumber, arl.id as arl_id, arld.id as arld_id
+into {pmf_schema}.annual_report_log_deletions
+from annual_report_logs arl
+inner join persons p on p.id = arl.client_id
+inner join earliest_order eo on eo.caserecnumber = p.caserecnumber
+left join annual_report_lodging_details arld ON arl.id = arld.annual_report_log_id
+where arl.reportingperiodenddate::timestamp < eo.orderdate::timestamp;
+
+--@audit_tag
+select arl.*
+into {pmf_schema}.annual_report_logs_audit
+from annual_report_logs arl
+inner join {pmf_schema}.annual_report_log_deletions del on arl.id = del.arl_id;
+
+select arld.*
+into {pmf_schema}.annual_report_lodging_details_audit
+from annual_report_lodging_details arld
+inner join {pmf_schema}.annual_report_log_deletions del on arld.id = del.arld_id;
+
+--@update_tag
+DELETE FROM annual_report_lodging_details
+WHERE id IN (select id from {pmf_schema}.annual_report_lodging_details_audit);
+
+DELETE FROM annual_report_logs
+WHERE id IN (select id from {pmf_schema}.annual_report_logs_audit);
+
+--@validate_tag
+SELECT arl.*
+FROM {pmf_schema}.annual_report_logs_audit arla
+INNER JOIN annual_report_logs arl ON arl.id = arla.id;
+
+SELECT arld.*
+FROM {pmf_schema}.annual_report_lodging_details_audit arlda
+INNER JOIN annual_report_lodging_details arld ON arld.id = arlda.id;

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/24_pmf_reports_in1267/annual_report_logs.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/24_pmf_reports_in1267/annual_report_logs.sql
@@ -1,39 +1,40 @@
---Purpose: Remove reports on P3 deputies that are prior to first order date as they were entered erroneously
+--Purpose: Remove reports on P3 deputies that are prior to first order date AS they were entered erroneously
 --@setup_tag
 CREATE SCHEMA IF NOT EXISTS {pmf_schema};
 
-WITH earliest_order as
-(select distinct on (p.caserecnumber) p.caserecnumber, c.orderdate
-from persons p
-inner join cases c on c.client_id = p.id
-where p.clientsource = 'CASRECMIGRATION_P3' --Only run for this phase
-and p.type = 'actor_client'
-order by p.caserecnumber, c.orderdate asc)
-select p.caserecnumber, arl.id as arl_id, arld.id as arld_id
-into {pmf_schema}.annual_report_log_deletions
-from annual_report_logs arl
-inner join persons p on p.id = arl.client_id
-inner join earliest_order eo on eo.caserecnumber = p.caserecnumber
-left join annual_report_lodging_details arld ON arl.id = arld.annual_report_log_id
-where arl.reportingperiodenddate::timestamp < eo.orderdate::timestamp;
+WITH earliest_order AS
+(SELECT DISTINCT ON (p.caserecnumber) p.caserecnumber, c.orderdate
+FROM persons p
+INNER JOIN cases c ON c.client_id = p.id
+WHERE p.clientsource = 'CASRECMIGRATION_P3' --Only run for this phase
+AND p.type = 'actor_client'
+order by p.caserecnumber, c.orderdate ASC)
+SELECT p.caserecnumber, arl.id AS arl_id, arld.id AS arld_id
+INTO {pmf_schema}.annual_report_log_deletions
+FROM annual_report_logs arl
+INNER JOIN persons p ON p.id = arl.client_id
+INNER JOIN earliest_order eo ON eo.caserecnumber = p.caserecnumber
+LEFT JOIN annual_report_lodging_details arld ON arl.id = arld.annual_report_log_id
+WHERE (arl.reportingperiodenddate::timestamp < eo.orderdate::timestamp)
+OR (arl.reportingperiodstartdate::timestamp < '2007-10-01 00:00:00'::timestamp);
 
 --@audit_tag
-select arl.*
-into {pmf_schema}.annual_report_logs_audit
-from annual_report_logs arl
-inner join {pmf_schema}.annual_report_log_deletions del on arl.id = del.arl_id;
+SELECT arl.*
+INTO {pmf_schema}.annual_report_logs_audit
+FROM annual_report_logs arl
+INNER JOIN {pmf_schema}.annual_report_log_deletions del ON arl.id = del.arl_id;
 
-select arld.*
-into {pmf_schema}.annual_report_lodging_details_audit
-from annual_report_lodging_details arld
-inner join {pmf_schema}.annual_report_log_deletions del on arld.id = del.arld_id;
+SELECT arld.*
+INTO {pmf_schema}.annual_report_lodging_details_audit
+FROM annual_report_lodging_details arld
+INNER JOIN {pmf_schema}.annual_report_log_deletions del ON arld.id = del.arld_id;
 
 --@update_tag
 DELETE FROM annual_report_lodging_details
-WHERE id IN (select id from {pmf_schema}.annual_report_lodging_details_audit);
+WHERE id IN (SELECT id FROM {pmf_schema}.annual_report_lodging_details_audit);
 
 DELETE FROM annual_report_logs
-WHERE id IN (select id from {pmf_schema}.annual_report_logs_audit);
+WHERE id IN (SELECT id FROM {pmf_schema}.annual_report_logs_audit);
 
 --@validate_tag
 SELECT arl.*

--- a/terraform/environment/tasks.toml
+++ b/terraform/environment/tasks.toml
@@ -447,7 +447,7 @@
         },
         "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/reindex-elasticsearch-by-date-${cluster}"
       },
-      "elasticsearch-reindex": {
+      "reindex-elasticsearch": {
         "Cluster": "${cluster}",
         "LaunchType": "FARGATE",
         "NetworkConfiguration": {
@@ -461,7 +461,7 @@
             ]
           }
         },
-        "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/elasticsearch-reindex-${cluster}"
+        "TaskDefinition": "arn:aws:ecs:eu-west-1:${account}:task-definition/reindex-elasticsearch-${cluster}"
       },
       "post-casrec-migration-script-update-report-status": {
         "Cluster": "${cluster}",


### PR DESCRIPTION
## Purpose

There are a number of reports in casrec that are on the cases before any orders were made. This is due to a casrec decision from years ago but is confusing now that they're being moved to sirius and the data shouldn't be there. 

## Approach

PMF to remove it

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
