### PR TITLE
In 1272 PMF25 fix airmailrequired flag

### DIFF
--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/25_pmf_address_in1272/address.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/25_pmf_address_in1272/address.sql
@@ -1,155 +1,34 @@
 --@setup_tag
-CREATE SCHEMA IF NOT EXISTS jacktest;
+CREATE SCHEMA IF NOT EXISTS {pmf_schema};
 
--- clients P1
-WITH clients_p1 AS (
+-- create a worker deputy table as the persons table is too large/slow
+SELECT id, deputynumber, clientsource
+INTO {pmf_schema}.deputies
+FROM persons
+WHERE type = 'actor_deputy'
+AND clientsource LIKE '{client_source}';
+CREATE INDEX idx_pmf1272_deputies_id ON {pmf_schema}.deputies USING btree (id);
+CREATE INDEX idx_pmf1272_deputies_deputynumber ON {pmf_schema}.deputies USING btree (deputynumber);
+
+-- client addresses
+WITH clients AS (
     SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
-    FROM casrec_csv.pat
+    FROM {casrec_schema}.pat
     LEFT JOIN persons p
         ON p.caserecnumber = pat."Case"
     LEFT JOIN addresses a
         ON a.person_id = p.id
     WHERE p.type = 'actor_client'
-    AND clientsource = 'CASRECMIGRATION'
+    AND clientsource = '{client_source}'
     AND pat."Foreign" = '1'
     AND (a.isairmailrequired IS NULL OR a.isairmailrequired != True)
 )
 SELECT *
-INTO jacktest.client_address_updates_p1
-FROM clients_p1;
+INTO {pmf_schema}.client_address_updates
+FROM clients;
 -- ~100
 
--- clients P2
-WITH clients_p2 AS (
-    SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
-    FROM casrec_csv_p2.pat
-        LEFT JOIN persons p
-    ON p.caserecnumber = pat."Case"
-        LEFT JOIN addresses a
-    ON a.person_id = p.id
-    WHERE p.type = 'actor_client'
-    AND clientsource = 'CASRECMIGRATION_P2'
-    AND pat."Foreign" = '1'
-    AND (a.isairmailrequired IS NULL OR a.isairmailrequired != True)
-)
-SELECT *
-INTO jacktest.client_address_updates_p2
-FROM clients_p2;
--- 0
-
--- clients P3
-WITH clients_p3 AS (
-    SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
-    FROM casrec_csv_p3.pat
-    LEFT JOIN persons p
-    ON p.caserecnumber = pat."Case"
-    LEFT JOIN addresses a
-    ON a.person_id = p.id
-    WHERE p.type = 'actor_client'
-    AND clientsource = 'CASRECMIGRATION_P3'
-    AND pat."Foreign" = '1'
-    AND (a.isairmailrequired IS NULL OR a.isairmailrequired != True)
-)
-SELECT *
-INTO jacktest.client_address_updates_p3
-FROM clients_p3;
--- 0
-
-
---@audit_tag
--- clients P1
-SELECT a.*
-INTO jacktest.client_address_audit_p1
-FROM addresses a
-INNER JOIN jacktest.client_address_updates_p1 cli
-    ON cli.address_id = a.id;
-
--- clients P2
-SELECT a.*
-INTO jacktest.client_address_audit_p2
-FROM addresses a
-INNER JOIN jacktest.client_address_updates_p2 cli
-    ON cli.address_id = a.id;
-
--- clients P3
-SELECT a.*
-INTO jacktest.client_address_audit_p3
-FROM addresses a
-INNER JOIN jacktest.client_address_updates_p3 cli
-    ON cli.address_id = a.id;
-
-
---@update_tag
--- clients P1
-UPDATE addresses a
-SET isairmailrequired = u.expected
-FROM jacktest.client_address_updates_p1 u
-WHERE u.address_id = a.id;
-
--- clients P2
-UPDATE addresses a
-SET isairmailrequired = u.expected
-FROM jacktest.client_address_updates_p2 u
-WHERE u.address_id = a.id;
-
--- clients P3
-UPDATE addresses a
-SET isairmailrequired = u.expected
-FROM jacktest.client_address_updates_p3 u
-WHERE u.address_id = a.id;
-
-
---@validate_tag
--- clients P1
-SELECT COUNT (1) FROM (
-    SELECT address_id, expected
-    FROM jacktest.client_address_updates_p1
-    EXCEPT
-    SELECT a.id, a.isairmailrequired
-    FROM addresses a
-    INNER JOIN jacktest.client_address_audit_p1 aud
-        ON aud.id = a.id
-) t1;
--- 100
-
--- clients P2
-SELECT COUNT (1) FROM (
-    SELECT address_id, expected
-    FROM jacktest.client_address_updates_p2
-    EXCEPT
-    SELECT a.id, a.isairmailrequired
-    FROM addresses a
-    INNER JOIN jacktest.client_address_audit_p2 aud
-        ON aud.id = a.id
-) t1;
--- 0 ZERO - NO NEED TO UPDATE
-
--- clients P3
-SELECT COUNT (1) FROM (
-    SELECT address_id, expected
-    FROM jacktest.client_address_updates_p3
-    EXCEPT
-    SELECT a.id, a.isairmailrequired
-    FROM addresses a
-    INNER JOIN jacktest.client_address_audit_p3 aud
-        ON aud.id = a.id
-) t1;
--- 0 ZERO - NO NEED TO UPDATE
-
-
--- D E P U T I E S --
-
--- create a worker deputy table as the persons table is too large/slow
-DROP TABLE IF EXISTS jacktest.deputies;
-SELECT id, deputynumber, clientsource
-INTO jacktest.deputies
-FROM persons
-WHERE type = 'actor_deputy'
-AND clientsource LIKE 'CASRECMIGRATION%';
-CREATE INDEX idx_pmf1272_deputies_id ON jacktest.deputies USING btree (id);
-CREATE INDEX idx_pmf1272_deputies_deputynumber ON jacktest.deputies USING btree (deputynumber);
-
--- deputies P1
+-- deputy addresses
 WITH overseas_deputies AS (
     SELECT DISTINCT * FROM (
         SELECT
@@ -157,12 +36,12 @@ WITH overseas_deputies AS (
             ds."Case",
             ds."Deputy No",
             row_number() over (PARTITION BY ds."Case", ds."Deputy No") AS rownum
-        FROM casrec_csv.deputy_address da
-        INNER JOIN casrec_csv.deputyship ds
+        FROM {casrec_schema}.deputy_address da
+        INNER JOIN {casrec_schema}.deputyship ds
             ON ds."Dep Addr No" = da."Dep Addr No"
-        INNER JOIN jacktest.deputies d
+        INNER JOIN {pmf_schema}.deputies d
             ON d.deputynumber = CAST(ds."Deputy No" AS INT)
-            AND d.clientsource = 'CASRECMIGRATION'
+            AND d.clientsource = '{client_source}'
         WHERE da."Foreign" = '1'
     ) t1 WHERE rownum = 1
 )
@@ -171,147 +50,65 @@ SELECT
     od."Case",
     True AS expected,
     a.isairmailrequired AS actual
-INTO jacktest.deputy_address_updates_p1
+INTO  {pmf_schema}.deputy_address_updates
 FROM addresses a
 INNER JOIN overseas_deputies od
     ON od.id = a.person_id
 WHERE (a.isairmailrequired IS NULL OR a.isairmailrequired != True);
 -- 543
 
--- deputies P2
-WITH overseas_deputies AS (
-    SELECT DISTINCT * FROM (
-        SELECT
-            d.id,
-            ds."Case",
-            ds."Deputy No",
-            row_number() over (PARTITION BY ds."Case", ds."Deputy No") AS rownum
-        FROM casrec_csv_p2.deputy_address da
-        INNER JOIN casrec_csv_p2.deputyship ds
-            ON ds."Dep Addr No" = da."Dep Addr No"
-        INNER JOIN jacktest.deputies d
-            ON d.deputynumber = CAST(ds."Deputy No" AS INT)
-            AND d.clientsource = 'CASRECMIGRATION_P2'
-        WHERE da."Foreign" = '1'
-    ) t1 WHERE rownum = 1
-)
-SELECT
-    a.id AS address_id,
-    od."Case",
-    True AS expected,
-    a.isairmailrequired AS actual
-INTO jacktest.deputy_address_updates_p2
-FROM addresses a
-INNER JOIN overseas_deputies od
-    ON od.id = a.person_id
-WHERE (a.isairmailrequired IS NULL OR a.isairmailrequired != True);
--- 0
-
--- deputies P3
-WITH overseas_deputies AS (
-    SELECT DISTINCT * FROM (
-        SELECT
-            d.id,
-            ds."Case",
-            ds."Deputy No",
-            row_number() over (PARTITION BY ds."Case", ds."Deputy No") AS rownum
-        FROM casrec_csv_p3.deputy_address da
-        INNER JOIN casrec_csv_p3.deputyship ds
-            ON ds."Dep Addr No" = da."Dep Addr No"
-        INNER JOIN jacktest.deputies d
-            ON d.deputynumber = CAST(ds."Deputy No" AS INT)
-            AND d.clientsource = 'CASRECMIGRATION_P3'
-        WHERE da."Foreign" = '1'
-    ) t1 WHERE rownum = 1
-)
-SELECT
-    a.id AS address_id,
-    od."Case",
-    True AS expected,
-    a.isairmailrequired AS actual
-INTO jacktest.deputy_address_updates_p3
-FROM addresses a
-INNER JOIN overseas_deputies od
-    ON od.id = a.person_id
-WHERE (a.isairmailrequired IS NULL OR a.isairmailrequired != True);
--- 0
 
 --@audit_tag
--- deputy addresses P1
+-- client addresses
 SELECT a.*
-INTO jacktest.deputy_address_audit_p1
+INTO {pmf_schema}.client_address_audit
 FROM addresses a
-INNER JOIN jacktest.deputy_address_updates_p1 dau
-    ON dau.address_id = a.id;
+INNER JOIN {pmf_schema}.client_address_updates cli
+    ON cli.address_id = a.id;
 
--- deputy addresses P2
+-- deputy addresses
 SELECT a.*
-INTO jacktest.deputy_address_audit_p2
+INTO {pmf_schema}.deputy_address_audit
 FROM addresses a
-INNER JOIN jacktest.deputy_address_updates_p2 dau
-    ON dau.address_id = a.id;
-
--- deputy addresses P3
-SELECT a.*
-INTO jacktest.deputy_address_audit_p3
-FROM addresses a
-INNER JOIN jacktest.deputy_address_updates_p3 dau
+INNER JOIN {pmf_schema}.deputy_address_updates dau
     ON dau.address_id = a.id;
 
 
 --@update_tag
--- deputies P1
+-- client addresses
 UPDATE addresses a
 SET isairmailrequired = u.expected
-FROM jacktest.deputy_address_updates_p1 u
+FROM {pmf_schema}.client_address_updates u
 WHERE u.address_id = a.id;
 
--- deputies P2
+-- deputy addresses
 UPDATE addresses a
 SET isairmailrequired = u.expected
-FROM jacktest.deputy_address_updates_p2 u
-WHERE u.address_id = a.id;
-
--- deputies P3
-UPDATE addresses a
-SET isairmailrequired = u.expected
-FROM jacktest.deputy_address_updates_p3 u
+FROM {pmf_schema}.deputy_address_updates u
 WHERE u.address_id = a.id;
 
 
 --@validate_tag
--- deputies P1
-SELECT COUNT(1) FROM (
-    SELECT DISTINCT address_id, expected
-    FROM jacktest.deputy_address_updates_p1
-    EXCEPT
-    SELECT DISTINCT a.id, a.isairmailrequired
-    FROM addresses a
-    INNER JOIN jacktest.deputy_address_audit_p1 aud
-        ON aud.id = a.id
-) t1;
--- 540
-
--- deputies P2
-SELECT COUNT(1) FROM (
-    SELECT DISTINCT address_id, expected
-    FROM jacktest.deputy_address_updates_p2
-    EXCEPT
-    SELECT DISTINCT a.id, a.isairmailrequired
-    FROM addresses a
-    INNER JOIN jacktest.deputy_address_audit_p2 aud
-        ON aud.id = a.id
-) t1;
--- 0
-
--- deputies P3
-SELECT COUNT(1) FROM (
+-- client addresses
+SELECT COUNT (1) FROM (
     SELECT address_id, expected
-    FROM jacktest.deputy_address_updates_p3
+    FROM {pmf_schema}.client_address_updates
     EXCEPT
     SELECT a.id, a.isairmailrequired
     FROM addresses a
-    INNER JOIN jacktest.deputy_address_audit_p3 aud
+    INNER JOIN {pmf_schema}.client_address_audit aud
         ON aud.id = a.id
 ) t1;
--- 0
+-- 100
+
+-- deputy addresses
+SELECT COUNT(1) FROM (
+    SELECT DISTINCT address_id, expected
+    FROM {pmf_schema}.deputy_address_updates
+    EXCEPT
+    SELECT DISTINCT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN {pmf_schema}.deputy_address_audit aud
+        ON aud.id = a.id
+) t1;
+-- 540

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/25_pmf_address_in1272/address.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/25_pmf_address_in1272/address.sql
@@ -6,16 +6,18 @@ WITH clients_p1 AS (
     SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
     FROM casrec_csv.pat
     LEFT JOIN persons p
-    ON p.caserecnumber = pat."Case"
+        ON p.caserecnumber = pat."Case"
     LEFT JOIN addresses a
-    ON a.person_id = p.id
+        ON a.person_id = p.id
     WHERE p.type = 'actor_client'
     AND clientsource = 'CASRECMIGRATION'
     AND pat."Foreign" = '1'
+    AND (a.isairmailrequired IS NULL OR a.isairmailrequired != True)
 )
 SELECT *
 INTO jacktest.client_address_updates_p1
 FROM clients_p1;
+-- ~100
 
 -- clients P2
 WITH clients_p2 AS (
@@ -28,10 +30,12 @@ WITH clients_p2 AS (
     WHERE p.type = 'actor_client'
     AND clientsource = 'CASRECMIGRATION_P2'
     AND pat."Foreign" = '1'
+    AND (a.isairmailrequired IS NULL OR a.isairmailrequired != True)
 )
 SELECT *
 INTO jacktest.client_address_updates_p2
 FROM clients_p2;
+-- 0
 
 -- clients P3
 WITH clients_p3 AS (
@@ -44,33 +48,35 @@ WITH clients_p3 AS (
     WHERE p.type = 'actor_client'
     AND clientsource = 'CASRECMIGRATION_P3'
     AND pat."Foreign" = '1'
+    AND (a.isairmailrequired IS NULL OR a.isairmailrequired != True)
 )
 SELECT *
 INTO jacktest.client_address_updates_p3
 FROM clients_p3;
+-- 0
 
 
 --@audit_tag
 -- clients P1
-SELECT p.*
+SELECT a.*
 INTO jacktest.client_address_audit_p1
-FROM persons p
+FROM addresses a
 INNER JOIN jacktest.client_address_updates_p1 cli
-    ON cli.caserecnumber = p.caserecnumber;
+    ON cli.address_id = a.id;
 
 -- clients P2
-SELECT p.*
+SELECT a.*
 INTO jacktest.client_address_audit_p2
-FROM persons p
+FROM addresses a
 INNER JOIN jacktest.client_address_updates_p2 cli
-    ON cli.caserecnumber = p.caserecnumber;
+    ON cli.address_id = a.id;
 
 -- clients P3
-SELECT p.*
+SELECT a.*
 INTO jacktest.client_address_audit_p3
-FROM persons p
+FROM addresses a
 INNER JOIN jacktest.client_address_updates_p3 cli
-    ON cli.caserecnumber = p.caserecnumber;
+    ON cli.address_id = a.id;
 
 
 --@update_tag
@@ -95,31 +101,40 @@ WHERE u.address_id = a.id;
 
 --@validate_tag
 -- clients P1
-SELECT address_id, expected
-FROM jacktest.client_address_updates_p1
-EXCEPT
-SELECT id, isairmailrequired
-FROM addresses a
-INNER JOIN jacktest.client_address_audit_p1 aud
-    ON aud.id = a.id;
+SELECT COUNT (1) FROM (
+    SELECT address_id, expected
+    FROM jacktest.client_address_updates_p1
+    EXCEPT
+    SELECT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN jacktest.client_address_audit_p1 aud
+        ON aud.id = a.id
+) t1;
+-- 100
 
 -- clients P2
-SELECT address_id, expected
-FROM jacktest.client_address_updates_p2
-EXCEPT
-SELECT id, isairmailrequired
-FROM addresses a
-INNER JOIN jacktest.client_address_audit_p2 aud
-    ON aud.id = a.id;
+SELECT COUNT (1) FROM (
+    SELECT address_id, expected
+    FROM jacktest.client_address_updates_p2
+    EXCEPT
+    SELECT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN jacktest.client_address_audit_p2 aud
+        ON aud.id = a.id
+) t1;
+-- 0 ZERO - NO NEED TO UPDATE
 
 -- clients P3
-SELECT address_id, expected
-FROM jacktest.client_address_updates_p3
-EXCEPT
-SELECT id, isairmailrequired
-FROM addresses a
-INNER JOIN jacktest.client_address_audit_p3 aud
-    ON aud.id = a.id;
+SELECT COUNT (1) FROM (
+    SELECT address_id, expected
+    FROM jacktest.client_address_updates_p3
+    EXCEPT
+    SELECT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN jacktest.client_address_audit_p3 aud
+        ON aud.id = a.id
+) t1;
+-- 0 ZERO - NO NEED TO UPDATE
 
 
 -- D E P U T I E S --
@@ -134,92 +149,114 @@ AND clientsource LIKE 'CASRECMIGRATION%';
 CREATE INDEX idx_pmf1272_deputies_id ON jacktest.deputies USING btree (id);
 CREATE INDEX idx_pmf1272_deputies_deputynumber ON jacktest.deputies USING btree (deputynumber);
 
-
 -- deputies P1
 WITH overseas_deputies AS (
-    SELECT DISTINCT
-    d.id,
-    ds."Deputy No"
-    FROM casrec_csv.deputy_address da
-    INNER JOIN casrec_csv.deputyship ds
-        ON ds."Dep Addr No" = da."Dep Addr No"
-    INNER JOIN jacktest.deputies d
-        ON d.deputynumber = CAST(ds."Deputy No" AS INT)
-    WHERE da."Foreign" = '1'
+    SELECT DISTINCT * FROM (
+        SELECT
+            d.id,
+            ds."Case",
+            ds."Deputy No",
+            row_number() over (PARTITION BY ds."Case", ds."Deputy No") AS rownum
+        FROM casrec_csv.deputy_address da
+        INNER JOIN casrec_csv.deputyship ds
+            ON ds."Dep Addr No" = da."Dep Addr No"
+        INNER JOIN jacktest.deputies d
+            ON d.deputynumber = CAST(ds."Deputy No" AS INT)
+            AND d.clientsource = 'CASRECMIGRATION'
+        WHERE da."Foreign" = '1'
+    ) t1 WHERE rownum = 1
 )
 SELECT
     a.id AS address_id,
+    od."Case",
     True AS expected,
     a.isairmailrequired AS actual
 INTO jacktest.deputy_address_updates_p1
 FROM addresses a
 INNER JOIN overseas_deputies od
-    ON od.id = a.person_id;
+    ON od.id = a.person_id
+WHERE (a.isairmailrequired IS NULL OR a.isairmailrequired != True);
+-- 543
 
 -- deputies P2
 WITH overseas_deputies AS (
-    SELECT DISTINCT
-    d.id,
-    ds."Deputy No"
-    FROM casrec_csv_p2.deputy_address da
-    INNER JOIN casrec_csv_p2.deputyship ds
-        ON ds."Dep Addr No" = da."Dep Addr No"
-    INNER JOIN jacktest.deputies d
-        ON d.deputynumber = CAST(ds."Deputy No" AS INT)
-    WHERE da."Foreign" = '1'
+    SELECT DISTINCT * FROM (
+        SELECT
+            d.id,
+            ds."Case",
+            ds."Deputy No",
+            row_number() over (PARTITION BY ds."Case", ds."Deputy No") AS rownum
+        FROM casrec_csv_p2.deputy_address da
+        INNER JOIN casrec_csv_p2.deputyship ds
+            ON ds."Dep Addr No" = da."Dep Addr No"
+        INNER JOIN jacktest.deputies d
+            ON d.deputynumber = CAST(ds."Deputy No" AS INT)
+            AND d.clientsource = 'CASRECMIGRATION_P2'
+        WHERE da."Foreign" = '1'
+    ) t1 WHERE rownum = 1
 )
 SELECT
     a.id AS address_id,
+    od."Case",
     True AS expected,
     a.isairmailrequired AS actual
 INTO jacktest.deputy_address_updates_p2
 FROM addresses a
 INNER JOIN overseas_deputies od
-    ON od.id = a.person_id;
+    ON od.id = a.person_id
+WHERE (a.isairmailrequired IS NULL OR a.isairmailrequired != True);
+-- 0
 
 -- deputies P3
 WITH overseas_deputies AS (
-    SELECT DISTINCT
-    d.id,
-    ds."Deputy No"
-    FROM casrec_csv_p3.deputy_address da
-    INNER JOIN casrec_csv_p3.deputyship ds
-        ON ds."Dep Addr No" = da."Dep Addr No"
-    INNER JOIN jacktest.deputies d
-        ON d.deputynumber = CAST(ds."Deputy No" AS INT)
-    WHERE da."Foreign" = '1'
+    SELECT DISTINCT * FROM (
+        SELECT
+            d.id,
+            ds."Case",
+            ds."Deputy No",
+            row_number() over (PARTITION BY ds."Case", ds."Deputy No") AS rownum
+        FROM casrec_csv_p3.deputy_address da
+        INNER JOIN casrec_csv_p3.deputyship ds
+            ON ds."Dep Addr No" = da."Dep Addr No"
+        INNER JOIN jacktest.deputies d
+            ON d.deputynumber = CAST(ds."Deputy No" AS INT)
+            AND d.clientsource = 'CASRECMIGRATION_P3'
+        WHERE da."Foreign" = '1'
+    ) t1 WHERE rownum = 1
 )
 SELECT
     a.id AS address_id,
+    od."Case",
     True AS expected,
     a.isairmailrequired AS actual
 INTO jacktest.deputy_address_updates_p3
 FROM addresses a
 INNER JOIN overseas_deputies od
-    ON od.id = a.person_id;
-
+    ON od.id = a.person_id
+WHERE (a.isairmailrequired IS NULL OR a.isairmailrequired != True);
+-- 0
 
 --@audit_tag
 -- deputy addresses P1
 SELECT a.*
 INTO jacktest.deputy_address_audit_p1
 FROM addresses a
-INNER JOIN jacktest.deputy_address_updates_p1 du
-    ON du.address_id = a.id;
+INNER JOIN jacktest.deputy_address_updates_p1 dau
+    ON dau.address_id = a.id;
 
 -- deputy addresses P2
 SELECT a.*
 INTO jacktest.deputy_address_audit_p2
 FROM addresses a
-INNER JOIN jacktest.deputy_address_updates_p2 du
-    ON du.address_id = a.id;
+INNER JOIN jacktest.deputy_address_updates_p2 dau
+    ON dau.address_id = a.id;
 
 -- deputy addresses P3
 SELECT a.*
 INTO jacktest.deputy_address_audit_p3
 FROM addresses a
-INNER JOIN jacktest.deputy_address_updates_p3 du
-    ON du.address_id = a.id;
+INNER JOIN jacktest.deputy_address_updates_p3 dau
+    ON dau.address_id = a.id;
 
 
 --@update_tag
@@ -244,28 +281,37 @@ WHERE u.address_id = a.id;
 
 --@validate_tag
 -- deputies P1
-SELECT address_id, expected
-FROM jacktest.deputy_address_updates_p1
-EXCEPT
-SELECT id, isairmailrequired
-FROM addresses a
-INNER JOIN jacktest.deputy_address_audit_p1 aud
-    ON aud.id = a.id;
+SELECT COUNT(1) FROM (
+    SELECT DISTINCT address_id, expected
+    FROM jacktest.deputy_address_updates_p1
+    EXCEPT
+    SELECT DISTINCT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN jacktest.deputy_address_audit_p1 aud
+        ON aud.id = a.id
+) t1;
+-- 540
 
 -- deputies P2
-SELECT address_id, expected
-FROM jacktest.deputy_address_updates_p1
-EXCEPT
-SELECT id, isairmailrequired
-FROM addresses a
-INNER JOIN jacktest.deputy_address_audit_p1 aud
-    ON aud.id = a.id;
+SELECT COUNT(1) FROM (
+    SELECT DISTINCT address_id, expected
+    FROM jacktest.deputy_address_updates_p2
+    EXCEPT
+    SELECT DISTINCT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN jacktest.deputy_address_audit_p2 aud
+        ON aud.id = a.id
+) t1;
+-- 0
 
 -- deputies P3
-SELECT address_id, expected
-FROM jacktest.deputy_address_updates_p1
-EXCEPT
-SELECT id, isairmailrequired
-FROM addresses a
-INNER JOIN jacktest.deputy_address_audit_p1 aud
-    ON aud.id = a.id;
+SELECT COUNT(1) FROM (
+    SELECT address_id, expected
+    FROM jacktest.deputy_address_updates_p3
+    EXCEPT
+    SELECT a.id, a.isairmailrequired
+    FROM addresses a
+    INNER JOIN jacktest.deputy_address_audit_p3 aud
+        ON aud.id = a.id
+) t1;
+-- 0

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/25_pmf_address_in1272/address.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/25_pmf_address_in1272/address.sql
@@ -1,0 +1,271 @@
+--@setup_tag
+CREATE SCHEMA IF NOT EXISTS jacktest;
+
+-- clients P1
+WITH clients_p1 AS (
+    SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
+    FROM casrec_csv.pat
+    LEFT JOIN persons p
+    ON p.caserecnumber = pat."Case"
+    LEFT JOIN addresses a
+    ON a.person_id = p.id
+    WHERE p.type = 'actor_client'
+    AND clientsource = 'CASRECMIGRATION'
+    AND pat."Foreign" = '1'
+)
+SELECT *
+INTO jacktest.client_address_updates_p1
+FROM clients_p1;
+
+-- clients P2
+WITH clients_p2 AS (
+    SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
+    FROM casrec_csv_p2.pat
+        LEFT JOIN persons p
+    ON p.caserecnumber = pat."Case"
+        LEFT JOIN addresses a
+    ON a.person_id = p.id
+    WHERE p.type = 'actor_client'
+    AND clientsource = 'CASRECMIGRATION_P2'
+    AND pat."Foreign" = '1'
+)
+SELECT *
+INTO jacktest.client_address_updates_p2
+FROM clients_p2;
+
+-- clients P3
+WITH clients_p3 AS (
+    SELECT a.id AS address_id, "Case" AS caserecnumber, True AS expected, a.isairmailrequired AS actual
+    FROM casrec_csv_p3.pat
+    LEFT JOIN persons p
+    ON p.caserecnumber = pat."Case"
+    LEFT JOIN addresses a
+    ON a.person_id = p.id
+    WHERE p.type = 'actor_client'
+    AND clientsource = 'CASRECMIGRATION_P3'
+    AND pat."Foreign" = '1'
+)
+SELECT *
+INTO jacktest.client_address_updates_p3
+FROM clients_p3;
+
+
+--@audit_tag
+-- clients P1
+SELECT p.*
+INTO jacktest.client_address_audit_p1
+FROM persons p
+INNER JOIN jacktest.client_address_updates_p1 cli
+    ON cli.caserecnumber = p.caserecnumber;
+
+-- clients P2
+SELECT p.*
+INTO jacktest.client_address_audit_p2
+FROM persons p
+INNER JOIN jacktest.client_address_updates_p2 cli
+    ON cli.caserecnumber = p.caserecnumber;
+
+-- clients P3
+SELECT p.*
+INTO jacktest.client_address_audit_p3
+FROM persons p
+INNER JOIN jacktest.client_address_updates_p3 cli
+    ON cli.caserecnumber = p.caserecnumber;
+
+
+--@update_tag
+-- clients P1
+UPDATE addresses a
+SET isairmailrequired = u.expected
+FROM jacktest.client_address_updates_p1 u
+WHERE u.address_id = a.id;
+
+-- clients P2
+UPDATE addresses a
+SET isairmailrequired = u.expected
+FROM jacktest.client_address_updates_p2 u
+WHERE u.address_id = a.id;
+
+-- clients P3
+UPDATE addresses a
+SET isairmailrequired = u.expected
+FROM jacktest.client_address_updates_p3 u
+WHERE u.address_id = a.id;
+
+
+--@validate_tag
+-- clients P1
+SELECT address_id, expected
+FROM jacktest.client_address_updates_p1
+EXCEPT
+SELECT id, isairmailrequired
+FROM addresses a
+INNER JOIN jacktest.client_address_audit_p1 aud
+    ON aud.id = a.id;
+
+-- clients P2
+SELECT address_id, expected
+FROM jacktest.client_address_updates_p2
+EXCEPT
+SELECT id, isairmailrequired
+FROM addresses a
+INNER JOIN jacktest.client_address_audit_p2 aud
+    ON aud.id = a.id;
+
+-- clients P3
+SELECT address_id, expected
+FROM jacktest.client_address_updates_p3
+EXCEPT
+SELECT id, isairmailrequired
+FROM addresses a
+INNER JOIN jacktest.client_address_audit_p3 aud
+    ON aud.id = a.id;
+
+
+-- D E P U T I E S --
+
+-- create a worker deputy table as the persons table is too large/slow
+DROP TABLE IF EXISTS jacktest.deputies;
+SELECT id, deputynumber, clientsource
+INTO jacktest.deputies
+FROM persons
+WHERE type = 'actor_deputy'
+AND clientsource LIKE 'CASRECMIGRATION%';
+CREATE INDEX idx_pmf1272_deputies_id ON jacktest.deputies USING btree (id);
+CREATE INDEX idx_pmf1272_deputies_deputynumber ON jacktest.deputies USING btree (deputynumber);
+
+
+-- deputies P1
+WITH overseas_deputies AS (
+    SELECT DISTINCT
+    d.id,
+    ds."Deputy No"
+    FROM casrec_csv.deputy_address da
+    INNER JOIN casrec_csv.deputyship ds
+        ON ds."Dep Addr No" = da."Dep Addr No"
+    INNER JOIN jacktest.deputies d
+        ON d.deputynumber = CAST(ds."Deputy No" AS INT)
+    WHERE da."Foreign" = '1'
+)
+SELECT
+    a.id AS address_id,
+    True AS expected,
+    a.isairmailrequired AS actual
+INTO jacktest.deputy_address_updates_p1
+FROM addresses a
+INNER JOIN overseas_deputies od
+    ON od.id = a.person_id;
+
+-- deputies P2
+WITH overseas_deputies AS (
+    SELECT DISTINCT
+    d.id,
+    ds."Deputy No"
+    FROM casrec_csv_p2.deputy_address da
+    INNER JOIN casrec_csv_p2.deputyship ds
+        ON ds."Dep Addr No" = da."Dep Addr No"
+    INNER JOIN jacktest.deputies d
+        ON d.deputynumber = CAST(ds."Deputy No" AS INT)
+    WHERE da."Foreign" = '1'
+)
+SELECT
+    a.id AS address_id,
+    True AS expected,
+    a.isairmailrequired AS actual
+INTO jacktest.deputy_address_updates_p2
+FROM addresses a
+INNER JOIN overseas_deputies od
+    ON od.id = a.person_id;
+
+-- deputies P3
+WITH overseas_deputies AS (
+    SELECT DISTINCT
+    d.id,
+    ds."Deputy No"
+    FROM casrec_csv_p3.deputy_address da
+    INNER JOIN casrec_csv_p3.deputyship ds
+        ON ds."Dep Addr No" = da."Dep Addr No"
+    INNER JOIN jacktest.deputies d
+        ON d.deputynumber = CAST(ds."Deputy No" AS INT)
+    WHERE da."Foreign" = '1'
+)
+SELECT
+    a.id AS address_id,
+    True AS expected,
+    a.isairmailrequired AS actual
+INTO jacktest.deputy_address_updates_p3
+FROM addresses a
+INNER JOIN overseas_deputies od
+    ON od.id = a.person_id;
+
+
+--@audit_tag
+-- deputy addresses P1
+SELECT a.*
+INTO jacktest.deputy_address_audit_p1
+FROM addresses a
+INNER JOIN jacktest.deputy_address_updates_p1 du
+    ON du.address_id = a.id;
+
+-- deputy addresses P2
+SELECT a.*
+INTO jacktest.deputy_address_audit_p2
+FROM addresses a
+INNER JOIN jacktest.deputy_address_updates_p2 du
+    ON du.address_id = a.id;
+
+-- deputy addresses P3
+SELECT a.*
+INTO jacktest.deputy_address_audit_p3
+FROM addresses a
+INNER JOIN jacktest.deputy_address_updates_p3 du
+    ON du.address_id = a.id;
+
+
+--@update_tag
+-- deputies P1
+UPDATE addresses a
+SET isairmailrequired = u.expected
+FROM jacktest.deputy_address_updates_p1 u
+WHERE u.address_id = a.id;
+
+-- deputies P2
+UPDATE addresses a
+SET isairmailrequired = u.expected
+FROM jacktest.deputy_address_updates_p2 u
+WHERE u.address_id = a.id;
+
+-- deputies P3
+UPDATE addresses a
+SET isairmailrequired = u.expected
+FROM jacktest.deputy_address_updates_p3 u
+WHERE u.address_id = a.id;
+
+
+--@validate_tag
+-- deputies P1
+SELECT address_id, expected
+FROM jacktest.deputy_address_updates_p1
+EXCEPT
+SELECT id, isairmailrequired
+FROM addresses a
+INNER JOIN jacktest.deputy_address_audit_p1 aud
+    ON aud.id = a.id;
+
+-- deputies P2
+SELECT address_id, expected
+FROM jacktest.deputy_address_updates_p1
+EXCEPT
+SELECT id, isairmailrequired
+FROM addresses a
+INNER JOIN jacktest.deputy_address_audit_p1 aud
+    ON aud.id = a.id;
+
+-- deputies P3
+SELECT address_id, expected
+FROM jacktest.deputy_address_updates_p1
+EXCEPT
+SELECT id, isairmailrequired
+FROM addresses a
+INNER JOIN jacktest.deputy_address_audit_p1 aud
+    ON aud.id = a.id;


### PR DESCRIPTION
## Purpose

Fix airmailrequired flag, which was not set on migration 1 for deputies and client addresses which are overseas. (problem not found in Phases 2 & 3)

## Approach

Standard PMF approach

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
