### PR TITLE
pmf27_sw6081_delete_cases_work

### DIFF
--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/README.md
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/README.md
@@ -1,0 +1,51 @@
+-- ===================== PMF27 SW6081 =====================
+-- Clean up of client data which OPG either should not have (was brought over with Livelink Migration)
+-- ...or which violates data retention rules on ticket https://opgtransform.atlassian.net/browse/SW-6081
+
+## A/C
+
+### Original A/c on ticket sw6081
+https://opgtransform.atlassian.net/browse/SW-6081
+-- 1. Keep cases which now have an order attached. 
+-- 2. Delete all cases without an order, which have no activity within the last 3 months
+-- 3. Keep cases with activity within the past 3 months
+-- 4. Keep the approx 380 cases within the spreadsheets attached to the above ticket
+-- 5. Maintain a full copy of everything deleted in audit tables, ala other Migration Project 'PMF fixes'
+
+### Update 14th Oct 2022
+Delete clients without an order, irrespective of last activity "No order = delete"
+https://docs.google.com/spreadsheets/d/1ISr32pT5Pl7Q-bRVwjwg2F92lbVgvQQL4gx82K584ek/edit#gid=1458605647
+
+### Update 2
+The 'exceptions' have now all been handled, therefore the 380 cases that were to be preserved can now also be deleted.
+
+## Runbook
+
+### Setup
+CAUTION!!! RUN THIS ONLY ONCE, BEFORE FIRST RUN. IT WILL DELETE THE SCHEMA.
+
+```bash
+$ chmod 744 sw6081/*.sh
+$ psql -f sw6081/setup_CAUTION_run_once.sql
+```
+
+### Run
+```bash
+# Create Run Data
+$ ./sw6081/run_prepare.sh
+
+# Delete (follow prompts)
+$ ./sw6081/run_delete.sh
+```
+
+### Get results 
+```bash
+# print various delete runs
+$ psql -c 'SELECT * FROM deleted_cases_sw6081.run'
+
+# print deletion results
+$ psql -c 'SELECT * FROM deleted_cases_sw6081.results'
+
+# search for a client that was deleted
+$ psql -c "SELECT * FROM deleted_cases_sw6081.run_clients WHERE caserecnumber = '1324903T'"
+```

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/calc_last_activity.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/calc_last_activity.sql
@@ -1,0 +1,70 @@
+-- get event IDs (for person_timeline only, there are no cases, so no case TE)
+SELECT
+    pt.person_id,
+    pt.timelineevent_id
+INTO deleted_cases_sw6081.client_nodocs_events_ids
+FROM deleted_cases_sw6081.clients_selection cl
+INNER JOIN person_timeline pt
+    ON pt.person_id = cl.id;
+
+-- use ids to get full events
+SELECT tid.person_id, te.*
+INTO deleted_cases_sw6081.clients_selection_timeline_events
+FROM deleted_cases_sw6081.client_nodocs_events_ids tid
+INNER JOIN timeline_event te
+    ON te.id = tid.timelineevent_id;
+DROP TABLE deleted_cases_sw6081.client_nodocs_events_ids;
+
+-- Delete timeline events which do not contribute to establishing 'Last Action' in Sirius
+DELETE FROM deleted_cases_sw6081.clients_selection_timeline_events WHERE event->'payload'->>'subject' = 'Migration Notice';
+DELETE FROM deleted_cases_sw6081.clients_selection_timeline_events WHERE eventtype = 'Opg\Core\Model\Event\Person\DeputyContactDetailsChanged';
+DELETE FROM deleted_cases_sw6081.clients_selection_timeline_events WHERE eventtype = 'Opg\Core\Model\Event\Person\PaDetailsChanged';
+
+-- now assess last action based on available data
+ALTER TABLE deleted_cases_sw6081.clients_selection ADD COLUMN latest_timestamp timestamp;
+ALTER TABLE deleted_cases_sw6081.clients_selection ADD COLUMN latest_activity date;
+
+-- calculate and update each row with last activity date
+WITH latest_timeline AS(
+    SELECT person_id, MAX(timestamp) as latest_timestamp
+    FROM deleted_cases_sw6081.clients_selection_timeline_events te
+    GROUP BY person_id
+)
+UPDATE deleted_cases_sw6081.clients_selection cl
+SET latest_timestamp = t1.latest_timestamp,
+    latest_activity = t1.latest_activity
+FROM(
+    SELECT
+        cl.id,
+        CAST(lt.latest_timestamp AS DATE),
+        GREATEST(
+            CAST(statusdate AS DATE),
+            CAST(createddate AS DATE),
+            CAST(updateddate AS DATE),
+            CAST(lt.latest_timestamp AS DATE)
+        ) AS latest_activity
+    FROM deleted_cases_sw6081.clients_selection cl
+    LEFT JOIN latest_timeline lt ON lt.person_id = cl.id
+) t1
+WHERE t1.id = cl.id;
+
+DROP TABLE deleted_cases_sw6081.clients_selection_timeline_events;
+
+INSERT INTO deleted_cases_sw6081.run_clients (
+    SELECT
+        id,
+        caserecnumber,
+        clientsource,
+        caseactorgroup,
+        supervisioncaseowner_id,
+        statusdate,
+        createddate,
+        updateddate,
+        latest_timestamp,
+        latest_activity,
+        :runId
+    FROM deleted_cases_sw6081.clients_selection
+--     WHERE latest_activity <= (current_date - INTERVAL '3 months')
+);
+
+DROP TABLE deleted_cases_sw6081.clients_selection;

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/delete.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/delete.sql
@@ -1,0 +1,206 @@
+-- addresses
+DELETE FROM addresses a
+USING deleted_cases_sw6081.deleted_addresses da
+WHERE a.id = da.id
+AND da.delete_run_id = :runId;
+
+-- annual_report_logs
+DELETE FROM annual_report_logs arl
+USING deleted_cases_sw6081.deleted_annual_report_logs darl
+WHERE darl.id = arl.id
+AND darl.delete_run_id = :runId;
+
+-- DELETE FROM
+-- annual_report_letter_status
+-- deleted_cases_sw6081.deleted_annual_report_letter_status deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- annual_report_type_assignments
+-- deleted_cases_sw6081.deleted_annual_report_type_assignments deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- annual_report_lodging_details
+DELETE FROM annual_report_lodging_details arld
+USING deleted_cases_sw6081.deleted_annual_report_lodging_details darld
+WHERE darld.id = arld.id
+AND darld.delete_run_id = :runId;
+
+-- death_notifications
+DELETE FROM death_notifications dn
+USING deleted_cases_sw6081.deleted_death_notifications ddn
+WHERE ddn.id = dn.id
+AND ddn.delete_run_id = :runId;
+
+-- finance_invoice
+DELETE FROM supervision.finance_invoice fi
+USING deleted_cases_sw6081.deleted_finance_invoice dfi
+WHERE dfi.id = fi.id
+AND dfi.delete_run_id = :runId;
+
+-- DELETE FROM
+-- finance_order
+-- deleted_cases_sw6081.deleted_finance_order deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- finance_remission_exemption
+-- deleted_cases_sw6081.deleted_finance_remission_exemption deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- finance_invoice_fee_range
+-- deleted_cases_sw6081.deleted_finance_invoice_fee_range deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- finance_ledger
+-- deleted_cases_sw6081.deleted_finance_ledger deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- finance_ledger_allocation
+-- deleted_cases_sw6081.deleted_finance_ledger_allocation deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- finance_person
+DELETE FROM supervision.finance_person fp
+USING deleted_cases_sw6081.deleted_finance_person dfp
+WHERE dfp.id = fp.id
+AND dfp.delete_run_id = :runId;
+
+-- person_note
+DELETE FROM person_note pn
+USING deleted_cases_sw6081.deleted_person_note dpn
+WHERE dpn.person_id = pn.person_id
+AND dpn.note_id = pn.note_id
+AND dpn.delete_run_id = :runId;
+
+-- notes
+DELETE FROM notes
+USING
+deleted_cases_sw6081.deleted_notes dn
+WHERE dn.id = notes.id
+AND dn.delete_run_id = :runId;
+
+-- DELETE FROM
+-- person_personreference
+-- deleted_cases_sw6081.deleted_person_personreference deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- person_references
+-- deleted_cases_sw6081.deleted_person_references deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- DELETE FROM
+-- person_research_preferences
+-- deleted_cases_sw6081.deleted_person_research_preferences deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- person_task
+DELETE FROM person_task pt
+USING deleted_cases_sw6081.deleted_person_task dpt
+WHERE dpt.person_id = pt.person_id
+AND dpt.task_id = pt.task_id
+AND dpt.delete_run_id = :runId;
+
+-- tasks
+DELETE FROM tasks t
+USING deleted_cases_sw6081.deleted_tasks dt
+WHERE dt.id = t.id
+AND dt.delete_run_id = :runId;
+
+-- person_timeline
+DELETE FROM person_timeline pt
+USING deleted_cases_sw6081.deleted_person_timeline dpt
+WHERE dpt.id = pt.id
+AND dpt.delete_run_id = :runId;
+
+-- timeline_event
+DELETE FROM timeline_event te
+USING deleted_cases_sw6081.deleted_timeline_event dte
+WHERE dte.id = te.id
+AND dte.delete_run_id = :runId;
+
+-- person_warning
+DELETE FROM person_warning pw
+USING deleted_cases_sw6081.deleted_person_warning dpw
+WHERE dpw.person_id = pw.person_id
+AND dpw.warning_id = pw.warning_id
+AND dpw.delete_run_id = :runId;
+
+-- warnings
+DELETE FROM warnings w
+USING deleted_cases_sw6081.deleted_warnings dw
+WHERE dw.id = w.id
+AND dw.delete_run_id = :runId;
+
+-- phonenumbers
+DELETE FROM phonenumbers pn
+USING deleted_cases_sw6081.deleted_phonenumbers dpn
+WHERE dpn.id = pn.id
+AND dpn.delete_run_id = :runId;
+
+-- supervision_notes
+DELETE FROM supervision_notes sn
+USING deleted_cases_sw6081.deleted_supervision_notes dsn
+WHERE dsn.id = sn.id
+AND dsn.delete_run_id = :runId;
+
+DELETE FROM visits v
+USING deleted_cases_sw6081.deleted_visits dv
+WHERE dv.id = v.id
+AND dv.delete_run_id = :runId;
+
+-- DELETE FROM
+-- cases
+-- deleted_cases_sw6081.deleted_cases deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+DELETE FROM person_document pd
+USING deleted_cases_sw6081.deleted_person_document dpd
+WHERE dpd.person_id = pd.person_id
+AND dpd.document_id = pd.document_id
+AND dpd.delete_run_id = :runId;
+
+-- document_pages
+DELETE FROM document_pages dp
+USING deleted_cases_sw6081.deleted_document_pages ddp
+WHERE ddp.id = dp.id
+AND ddp.delete_run_id = :runId;
+
+-- DELETE FROM
+-- document_secondaryrecipient
+-- deleted_cases_sw6081.deleted_document_secondaryrecipient deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- persons_contacts
+-- 1. remove links to contacts from within persons table
+UPDATE persons p SET executor_id = NULL
+WHERE p.id IN (
+    SELECT dpca.client_id
+    FROM deleted_cases_sw6081.deleted_persons_contacts dpc
+    INNER JOIN deleted_cases_sw6081.deleted_persons_contacts_audit dpca
+        ON dpca.id = dpc.id
+    WHERE dpc.delete_run_id = :runId
+)
+AND p.type='actor_client';
+
+DELETE FROM persons p
+USING deleted_cases_sw6081.deleted_persons_contacts dpc
+WHERE dpc.id = p.id
+AND dpc.delete_run_id = :runId
+AND p.type='actor_contact';
+
+-- persons_deputies
+-- DELETE FROM
+-- persons_deputies
+-- deleted_cases_sw6081.deleted_persons_deputies deletetable
+-- WHERE delete_table.delete_run_id = :runId;
+
+-- persons_clients
+DELETE FROM persons p
+USING deleted_cases_sw6081.run_clients rc
+WHERE rc.id = p.id
+AND rc.delete_run_id = :runId;

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/run_delete.sh
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/run_delete.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+CONFIRM="n"
+
+export RUN_MIN_ID=`psql -qtAXc "SELECT MIN(id) FROM deleted_cases_sw6081.run"`
+export RUN_MAX_ID=`psql -qtAXc "SELECT MAX(id) FROM deleted_cases_sw6081.run"`
+
+read -rp "Run ID? ($RUN_MIN_ID-$RUN_MAX_ID): " RUN_ID
+echo $RUN_ID
+
+if ! [[ "$RUN_ID" =~ ([0-9]+) ]];
+then
+    echo "Not a number... exiting"; exit 1
+fi
+
+export RUN_EXISTS=`psql -qtAXc "SELECT COUNT(1) FROM deleted_cases_sw6081.run WHERE id = $RUN_ID"`
+
+if [ $RUN_EXISTS != 1 ]
+then
+    echo "No run by that ID... exiting"
+    exit 1
+fi
+
+clear
+
+echo -e "Delete run $RUN_ID will delete the following data:\n\nnote: rows from the documents table are not deleted at this stage\n"
+
+psql -tc "
+SELECT
+    CASE WHEN delete_table = 'persons_clients_audit'
+        THEN 'persons (CLIENTS)'
+        ELSE delete_table
+    END,
+    run_$RUN_ID
+FROM deleted_cases_sw6081.results
+WHERE delete_table != 'documents'
+AND run_$RUN_ID > 0
+ORDER BY delete_table ASC"
+
+read -rp "ARE YOU SURE? (y/n) [n]: " CONFIRM
+if [ "$CONFIRM" == "y" ]
+then
+    echo $CONFIRM
+    echo "Running delete script for delete run $RUN_ID"
+    psql -f ./sw6081/delete.sql -v runId=$RUN_ID
+    psql -c "UPDATE deleted_cases_sw6081.run SET deleted_at = CURRENT_TIMESTAMP(0) WHERE id = $RUN_ID"
+else
+    echo $CONFIRM
+    echo "exiting"
+fi
+

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/run_prepare.sh
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/run_prepare.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -e
+
+export RUNLIMIT=5000
+
+# Part 1 - do cases without documens ~49,120
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=0
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=5000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=10000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=15000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=20000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=25000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=30000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=35000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=40000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_nodocuments.sql -v runId=$RUN_ID -v notePrefix='SW6081 part 1: clients without documents' -v runLimit=$RUNLIMIT -v runOffset=45000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+# Part 2 - now do cases with documens ~68,951
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=0
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=5000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=10000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=15000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=20000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=25000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=30000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=35000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=40000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=45000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=50000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=55000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=60000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+export RUN_ID=`psql -qtAXc "SELECT nextval('deleted_cases_sw6081.deleterun_id_seq')"`
+psql -f ./sw6081/select_cases_with_docs.sql -v runId=$RUN_ID -v notePrefix='SW6081: clients with documents' -v runLimit=$RUNLIMIT -v runOffset=65000
+psql -f ./sw6081/calc_last_activity.sql -v runId=$RUN_ID
+psql -f ./sw6081/save_audit_data.sql -v runId=$RUN_ID
+
+psql -c 'SELECT * FROM deleted_cases_sw6081.results ORDER BY delete_table ASC;'

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/save_audit_data.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/save_audit_data.sql
@@ -1,0 +1,618 @@
+-- addresses
+INSERT INTO deleted_cases_sw6081.deleted_addresses (
+    SELECT a.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN addresses a
+        ON cl.id = a.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_addresses_audit (
+    SELECT a.*
+    FROM deleted_cases_sw6081.deleted_addresses da
+    INNER JOIN addresses a
+        ON da.id = a.id
+    WHERE da.delete_run_id = :runId
+);
+
+-- annual_report_logs
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_logs (
+    SELECT arl.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN annual_report_logs arl
+        ON cl.id = arl.client_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_logs_audit (
+    SELECT arl.*
+    FROM deleted_cases_sw6081.deleted_annual_report_logs darl
+    INNER JOIN annual_report_logs arl
+        ON arl.id = darl.id
+    WHERE darl.delete_run_id = :runId
+);
+
+-- annual_report_letter_status
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_letter_status (
+    SELECT arls.id, :runId
+    FROM deleted_cases_sw6081.deleted_annual_report_logs arl
+    INNER JOIN annual_report_letter_status arls
+        ON arl.id = arls.annualreport_id
+    WHERE arl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_letter_status_audit (
+    SELECT arls.*
+    FROM deleted_cases_sw6081.deleted_annual_report_letter_status darls
+    INNER JOIN annual_report_letter_status arls
+        ON arls.id = darls.id
+    WHERE darls.delete_run_id = :runId
+);
+
+-- annual_report_type_assignments
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_type_assignments (
+    SELECT arta.id, :runId
+    FROM deleted_cases_sw6081.deleted_annual_report_logs arl
+    INNER JOIN annual_report_type_assignments arta
+        ON arta.annualreport_id = arl.id
+    WHERE arl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_type_assignments_audit (
+    SELECT arta.*
+    FROM deleted_cases_sw6081.deleted_annual_report_type_assignments darta
+    INNER JOIN annual_report_type_assignments arta
+        ON darta.id = arta.id
+    WHERE darta.delete_run_id = :runId
+);
+
+-- annual_report_lodging_details
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_lodging_details (
+    SELECT arld.id, :runId
+    FROM annual_report_lodging_details arld
+    INNER JOIN deleted_cases_sw6081.deleted_annual_report_logs arl
+        ON arld.annual_report_log_id = arl.id
+    WHERE arl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_annual_report_lodging_details_audit (
+    SELECT arld.*
+    FROM deleted_cases_sw6081.deleted_annual_report_lodging_details darld
+    INNER JOIN annual_report_lodging_details arld
+        ON darld.id = arld.id
+    WHERE darld.delete_run_id = :runId
+);
+
+-- death notifications
+INSERT INTO deleted_cases_sw6081.deleted_death_notifications (
+    SELECT dn.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN death_notifications dn
+        ON cl.id = dn.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_death_notifications_audit (
+    SELECT dn.*
+    FROM deleted_cases_sw6081.deleted_death_notifications ddn
+    INNER JOIN death_notifications dn
+        ON dn.id = ddn.id
+    WHERE ddn.delete_run_id = :runId
+);
+
+-- finance_person (supervision schema)
+INSERT INTO deleted_cases_sw6081.deleted_finance_person (
+    SELECT fp.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN supervision.finance_person fp
+        ON cl.id = fp.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_person_audit (
+    SELECT fp.*
+    FROM deleted_cases_sw6081.deleted_finance_person dfp
+    INNER JOIN supervision.finance_person fp
+        ON fp.id = dfp.id
+    WHERE dfp.delete_run_id = :runId
+);
+
+-- finance_invoice (supervision schema)
+INSERT INTO deleted_cases_sw6081.deleted_finance_invoice (
+    SELECT fi.id, :runId
+    FROM deleted_cases_sw6081.deleted_finance_person dfp
+    INNER JOIN supervision.finance_invoice fi
+        ON dfp.id = fi.finance_person_id
+    WHERE dfp.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_invoice_audit (
+    SELECT fi.*
+    FROM deleted_cases_sw6081.deleted_finance_invoice dfi
+    INNER JOIN supervision.finance_invoice fi
+        ON dfi.id = fi.id
+    WHERE dfi.delete_run_id = :runId
+);
+
+-- finance_order (supervision schema)
+INSERT INTO deleted_cases_sw6081.deleted_finance_order (
+    SELECT fo.id, :runId
+    FROM deleted_cases_sw6081.deleted_finance_person dfp
+    INNER JOIN supervision.finance_order fo
+        ON dfp.id = fo.finance_person_id
+    WHERE dfp.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_order_audit (
+    SELECT fo.*
+    FROM deleted_cases_sw6081.deleted_finance_order dfo
+    INNER JOIN supervision.finance_order fo
+        ON fo.id = dfo.id
+    WHERE dfo.delete_run_id = :runId
+);
+
+-- finance_remission_exemption (supervision schema)
+INSERT INTO deleted_cases_sw6081.deleted_finance_remission_exemption (
+    SELECT fre.id, :runId
+    FROM deleted_cases_sw6081.deleted_finance_person dfp
+    INNER JOIN supervision.finance_remission_exemption fre
+        ON dfp.id = fre.finance_person_id
+    WHERE dfp.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_remission_exemption_audit (
+    SELECT fre.*
+    FROM deleted_cases_sw6081.deleted_finance_remission_exemption dfre
+    INNER JOIN supervision.finance_remission_exemption fre
+        ON fre.id = dfre.id
+    WHERE dfre.delete_run_id = :runId
+);
+
+-- finance_invoice_fee_range
+INSERT INTO deleted_cases_sw6081.deleted_finance_invoice_fee_range (
+    SELECT fifr.id, :runId
+    FROM deleted_cases_sw6081.deleted_finance_invoice dfi
+    INNER JOIN finance_invoice_fee_range fifr
+        ON fifr.invoice_id = dfi.id
+    WHERE dfi.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_invoice_fee_range_audit (
+    SELECT fifr.*
+    FROM deleted_cases_sw6081.deleted_finance_invoice_fee_range dfifr
+    LEFT JOIN finance_invoice_fee_range fifr
+        ON fifr.id = dfifr.id
+    WHERE dfifr.delete_run_id = :runId
+);
+
+-- finance_leger
+INSERT INTO deleted_cases_sw6081.deleted_finance_ledger (
+    SELECT fl.id, :runId
+    FROM deleted_cases_sw6081.deleted_finance_person dfp
+    INNER JOIN finance_ledger fl
+        ON dfp.id = fl.finance_person_id
+    WHERE dfp.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_ledger_audit (
+    SELECT fl.*
+    FROM deleted_cases_sw6081.deleted_finance_ledger dfl
+    INNER JOIN finance_ledger fl
+        ON dfl.id = fl.id
+    WHERE dfl.delete_run_id = :runId
+);
+
+-- finance_leger_allocation
+INSERT INTO deleted_cases_sw6081.deleted_finance_ledger_allocation (
+    SELECT fla.id, :runId
+    FROM deleted_cases_sw6081.deleted_finance_ledger dfl
+    INNER JOIN finance_ledger_allocation fla
+        ON fla.ledger_entry_id = dfl.id
+    WHERE dfl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_finance_ledger_allocation_audit (
+    SELECT fla.*
+    FROM deleted_cases_sw6081.deleted_finance_ledger_allocation dfla
+    INNER JOIN finance_ledger_allocation fla
+        ON fla.id = dfla.id
+    WHERE dfla.delete_run_id = :runId
+);
+
+-- person_note
+INSERT INTO deleted_cases_sw6081.deleted_person_note (
+    SELECT pn.person_id, pn.note_id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_note pn
+        ON cl.id = pn.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_note_audit (
+    SELECT dpn.person_id, dpn.note_id
+    FROM deleted_cases_sw6081.deleted_person_note dpn
+    WHERE dpn.delete_run_id = :runId
+);
+
+-- notes
+INSERT INTO deleted_cases_sw6081.deleted_notes (
+    SELECT dpn.note_id, :runId
+    FROM deleted_cases_sw6081.deleted_person_note dpn
+    WHERE dpn.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_notes_audit (
+    SELECT n.*
+    FROM deleted_cases_sw6081.deleted_notes dn
+    INNER JOIN notes n
+        ON n.id = dn.id
+    WHERE dn.delete_run_id = :runId
+);
+
+-- person_person_reference
+INSERT INTO deleted_cases_sw6081.deleted_person_personreference (
+    SELECT ppr.person_id, ppr.person_reference_id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_personreference ppr
+        ON cl.id = ppr.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_personreference_audit (
+    SELECT dppr.person_id, dppr.person_reference_id
+    FROM deleted_cases_sw6081.deleted_person_personreference dppr
+    WHERE dppr.delete_run_id = :runId
+);
+
+-- person_references
+INSERT INTO deleted_cases_sw6081.deleted_person_references (
+    SELECT pr.id, :runId
+    FROM deleted_cases_sw6081.deleted_person_personreference dppr
+    INNER JOIN person_references pr
+        ON dppr.person_reference_id = pr.id
+    WHERE dppr.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_references_audit (
+    SELECT pr.*
+    FROM deleted_cases_sw6081.deleted_person_references dpr
+    INNER JOIN person_references pr
+        ON dpr.id = pr.id
+    WHERE dpr.delete_run_id = :runId
+);
+
+-- person_research_preferences
+INSERT INTO deleted_cases_sw6081.deleted_person_research_preferences (
+    SELECT prp.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_research_preferences prp
+        ON cl.id = prp.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_research_preferences_audit (
+    SELECT prp.*
+    FROM deleted_cases_sw6081.deleted_person_research_preferences dprp
+    INNER JOIN person_research_preferences prp
+        ON dprp.id = prp.id
+    WHERE dprp.delete_run_id = :runId
+);
+
+-- person_task
+INSERT INTO deleted_cases_sw6081.deleted_person_task (
+    SELECT pt.person_id, pt.task_id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_task pt
+        ON cl.id = pt.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_task_audit (
+    SELECT dpt.person_id, dpt.task_id
+    FROM deleted_cases_sw6081.deleted_person_task dpt
+    WHERE dpt.delete_run_id = :runId
+);
+
+-- tasks
+INSERT INTO deleted_cases_sw6081.deleted_tasks (
+    SELECT t.id, :runId
+    FROM deleted_cases_sw6081.deleted_person_task dpt
+    INNER JOIN tasks t
+        ON dpt.task_id = t.id
+    WHERE dpt.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_tasks_audit (
+    SELECT t.*
+    FROM deleted_cases_sw6081.deleted_tasks dt
+    INNER JOIN tasks t
+        ON t.id = dt.id
+    WHERE dt.delete_run_id = :runId
+);
+
+-- person_timeline
+INSERT INTO deleted_cases_sw6081.deleted_person_timeline (
+    SELECT pt.id, pt.person_id, pt.timelineevent_id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_timeline pt
+        ON cl.id = pt.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_timeline_audit (
+    SELECT dpt.id, dpt.person_id, dpt.timelineevent_id
+    FROM deleted_cases_sw6081.deleted_person_timeline dpt
+    WHERE dpt.delete_run_id = :runId
+);
+
+-- timeline_event
+INSERT INTO deleted_cases_sw6081.deleted_timeline_event (
+    SELECT te.id, :runId
+    FROM deleted_cases_sw6081.deleted_person_timeline dpt
+    INNER JOIN timeline_event te
+        ON dpt.timelineevent_id = te.id
+    WHERE dpt.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_timeline_event_audit (
+    SELECT te.*
+    FROM deleted_cases_sw6081.deleted_timeline_event dte
+    INNER JOIN timeline_event te
+        ON te.id = dte.id
+    WHERE dte.delete_run_id = :runId
+);
+
+-- person_warning
+INSERT INTO deleted_cases_sw6081.deleted_person_warning (
+    SELECT pw.person_id, pw.warning_id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_warning pw
+        ON cl.id = pw.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_warning_audit (
+    SELECT dpw.person_id, dpw.warning_id 
+    FROM deleted_cases_sw6081.deleted_person_warning dpw
+    WHERE dpw.delete_run_id = :runId
+);
+
+-- warnings
+INSERT INTO deleted_cases_sw6081.deleted_warnings (
+    SELECT w.id, :runId
+    FROM deleted_cases_sw6081.deleted_person_warning dpw
+    INNER JOIN warnings w
+        ON dpw.warning_id = w.id
+    WHERE dpw.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_warnings_audit (
+    SELECT w.*
+    FROM deleted_cases_sw6081.deleted_warnings dw
+    INNER JOIN warnings w
+        ON w.id = dw.id
+    WHERE dw.delete_run_id = :runId
+);
+
+-- phonenumbers
+INSERT INTO deleted_cases_sw6081.deleted_phonenumbers (
+    SELECT ph.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN phonenumbers ph
+        ON cl.id = ph.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_phonenumbers_audit (
+    SELECT ph.*
+    FROM deleted_cases_sw6081.deleted_phonenumbers dp
+    INNER JOIN phonenumbers ph
+        ON dp.id = ph.id
+    WHERE dp.delete_run_id = :runId
+);
+
+-- supervision_notes
+INSERT INTO deleted_cases_sw6081.deleted_supervision_notes (
+    SELECT sn.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN supervision_notes sn
+        ON cl.id = sn.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_supervision_notes_audit (
+    SELECT sn.*
+    FROM deleted_cases_sw6081.deleted_supervision_notes dsn
+    INNER JOIN supervision_notes sn
+        ON sn.id = dsn.id
+    WHERE dsn.delete_run_id = :runId
+);
+
+-- visits
+INSERT INTO deleted_cases_sw6081.deleted_visits (
+    SELECT v.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN visits v
+        ON cl.id = v.client_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_visits_audit (
+    SELECT v.*
+    FROM deleted_cases_sw6081.deleted_visits dv
+    INNER JOIN visits v
+        ON v.id = dv.id
+    WHERE dv.delete_run_id = :runId
+);
+
+-- should obviously be 0, unless something has gone very wrong
+-- cases
+INSERT INTO deleted_cases_sw6081.deleted_cases (
+    SELECT c.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN cases c
+        ON cl.id = c.client_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_cases_audit (
+    SELECT c.*
+    FROM deleted_cases_sw6081.deleted_cases dc
+    INNER JOIN cases c
+        ON c.id = dc.id
+    WHERE dc.delete_run_id = :runId
+);
+
+-- person_document
+INSERT INTO deleted_cases_sw6081.deleted_person_document (
+    SELECT pd.person_id, pd.document_id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN person_document pd
+        ON cl.id = pd.person_id
+    WHERE cl.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_person_document_audit (
+    SELECT dpd.person_id, dpd.document_id
+    FROM deleted_cases_sw6081.deleted_person_document dpd
+    WHERE dpd.delete_run_id = :runId
+);
+
+-- document_pages
+INSERT INTO deleted_cases_sw6081.deleted_document_pages (
+    SELECT dp.id, dp.document_id, :runId
+    FROM deleted_cases_sw6081.deleted_person_document dpd
+    INNER JOIN document_pages dp
+        ON dpd.document_id = dp.document_id
+    WHERE dpd.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_document_pages_audit (
+    SELECT dp.*
+    FROM deleted_cases_sw6081.deleted_document_pages ddp
+    INNER JOIN document_pages dp
+        ON dp.id = ddp.id
+    WHERE ddp.delete_run_id = :runId
+);
+
+-- document_secondaryrecipient
+INSERT INTO deleted_cases_sw6081.deleted_document_secondaryrecipient (
+    SELECT dsr.document_id, dsr.person_id, :runId
+    FROM deleted_cases_sw6081.deleted_person_document dpd
+    INNER JOIN document_secondaryrecipient dsr
+        ON dsr.document_id = dpd.document_id
+    WHERE dpd.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_document_secondaryrecipient_audit (
+    SELECT ddsr.document_id, ddsr.person_id
+    FROM deleted_cases_sw6081.deleted_document_secondaryrecipient ddsr
+    WHERE ddsr.delete_run_id = :runId
+);
+
+-- documents
+INSERT INTO deleted_cases_sw6081.deleted_documents (
+    SELECT d.id, :runId
+    FROM deleted_cases_sw6081.deleted_person_document dpd
+    INNER JOIN documents d
+        ON d.id = dpd.document_id
+    WHERE dpd.delete_run_id = :runId
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_documents_audit (
+    SELECT d.*
+    FROM deleted_cases_sw6081.deleted_documents dd
+    INNER JOIN documents d
+        ON d.id = dd.id
+    WHERE dd.delete_run_id = :runId
+);
+
+-- persons (contacts)
+INSERT INTO deleted_cases_sw6081.deleted_persons_contacts (
+    SELECT p.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN persons p
+        ON cl.id = p.client_id
+    WHERE cl.delete_run_id = :runId
+    AND p.type = 'actor_contact'
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_persons_contacts_audit (
+    SELECT p.*
+    FROM deleted_cases_sw6081.deleted_persons_contacts dpc
+    INNER JOIN persons p
+        ON dpc.id = p.id
+    WHERE dpc.delete_run_id = :runId
+);
+
+-- persons (deputies)
+INSERT INTO deleted_cases_sw6081.deleted_persons_deputies (
+    SELECT p.id, :runId
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN persons p
+        ON cl.id = p.id
+    WHERE cl.delete_run_id = :runId
+    AND p.type = 'actor_deputy'
+);
+
+INSERT INTO deleted_cases_sw6081.deleted_persons_deputies_audit (
+    SELECT p.*
+    FROM deleted_cases_sw6081.deleted_persons_deputies dpd
+    INNER JOIN persons p
+        ON dpd.id = p.id
+    WHERE dpd.delete_run_id = :runId
+);
+
+-- persons (clients)
+INSERT INTO deleted_cases_sw6081.deleted_persons_clients_audit (
+    SELECT p.*
+    FROM deleted_cases_sw6081.run_clients cl
+    INNER JOIN persons p
+        ON cl.id = p.id
+    WHERE cl.delete_run_id = :runId
+    AND p.type = 'actor_client'
+);
+
+-- ================================================
+-- 3. Add affected rows for each entity to results
+-- ================================================
+
+\set runColumnName run_:runId
+
+ALTER TABLE deleted_cases_sw6081.results ADD :runColumnName int;
+
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_addresses WHERE delete_run_id = :runId) WHERE delete_table = 'addresses';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_annual_report_logs WHERE delete_run_id = :runId) WHERE delete_table = 'annual_report_logs';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_annual_report_letter_status WHERE delete_run_id = :runId) WHERE delete_table = 'annual_report_letter_status';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_annual_report_type_assignments WHERE delete_run_id = :runId) WHERE delete_table = 'annual_report_type_assignments';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_annual_report_lodging_details WHERE delete_run_id = :runId) WHERE delete_table = 'annual_report_lodging_details';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_death_notifications WHERE delete_run_id = :runId) WHERE delete_table = 'death_notifications';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_person WHERE delete_run_id = :runId) WHERE delete_table = 'finance_person';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_invoice WHERE delete_run_id = :runId) WHERE delete_table = 'finance_invoice';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_order WHERE delete_run_id = :runId) WHERE delete_table = 'finance_order';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_remission_exemption WHERE delete_run_id = :runId) WHERE delete_table = 'finance_remission_exemption';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_invoice_fee_range WHERE delete_run_id = :runId) WHERE delete_table = 'finance_invoice_fee_range';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_ledger WHERE delete_run_id = :runId) WHERE delete_table = 'finance_ledger';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_finance_ledger_allocation WHERE delete_run_id = :runId) WHERE delete_table = 'finance_ledger_allocation';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_note WHERE delete_run_id = :runId) WHERE delete_table = 'person_note';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_notes WHERE delete_run_id = :runId) WHERE delete_table = 'notes';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_personreference WHERE delete_run_id = :runId) WHERE delete_table = 'person_personreference';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_references WHERE delete_run_id = :runId) WHERE delete_table = 'person_references';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_research_preferences WHERE delete_run_id = :runId) WHERE delete_table = 'person_research_preferences';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_task WHERE delete_run_id = :runId) WHERE delete_table = 'person_task';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_tasks WHERE delete_run_id = :runId) WHERE delete_table = 'tasks';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_timeline WHERE delete_run_id = :runId) WHERE delete_table = 'person_timeline';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_timeline_event WHERE delete_run_id = :runId) WHERE delete_table = 'timeline_event';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_warning WHERE delete_run_id = :runId) WHERE delete_table = 'person_warning';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_warnings WHERE delete_run_id = :runId) WHERE delete_table = 'warnings';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_phonenumbers WHERE delete_run_id = :runId) WHERE delete_table = 'phonenumbers';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_supervision_notes WHERE delete_run_id = :runId) WHERE delete_table = 'supervision_notes';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_visits WHERE delete_run_id = :runId) WHERE delete_table = 'visits';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_cases WHERE delete_run_id = :runId) WHERE delete_table = 'cases';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_person_document WHERE delete_run_id = :runId) WHERE delete_table = 'person_document';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_document_pages WHERE delete_run_id = :runId) WHERE delete_table = 'document_pages';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_document_secondaryrecipient WHERE delete_run_id = :runId) WHERE delete_table = 'document_secondaryrecipient';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_documents WHERE delete_run_id = :runId) WHERE delete_table = 'documents';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_persons_contacts WHERE delete_run_id = :runId) WHERE delete_table = 'persons_contacts';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.deleted_persons_deputies WHERE delete_run_id = :runId) WHERE delete_table = 'persons_deputies';
+UPDATE deleted_cases_sw6081.results SET :runColumnName = (SELECT COUNT(1) FROM deleted_cases_sw6081.run_clients WHERE delete_run_id = :runId) WHERE delete_table = 'persons_clients_audit';

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/select_cases_with_docs.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/select_cases_with_docs.sql
@@ -1,0 +1,18 @@
+-- establish subset of client (with no cases) WITH docs
+SELECT cl.*
+INTO deleted_cases_sw6081.clients_selection
+FROM deleted_cases_sw6081.clients_nocases_with_documents cl
+ORDER BY cl.id
+LIMIT :runLimit
+OFFSET :runOffset;
+
+-- new run
+INSERT INTO deleted_cases_sw6081.run (id, notes, selections_made_at, clients_affected)
+VALUES (
+    :runId,
+    CONCAT(:'notePrefix', ' - LIMIT: ', :runLimit, ', OFFSET: ', :runOffset),
+    CURRENT_TIMESTAMP(0),
+    (SELECT COUNT(1) FROM deleted_cases_sw6081.clients_selection)
+);
+
+SELECT * FROM deleted_cases_sw6081.run;

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/select_nodocuments.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/select_nodocuments.sql
@@ -1,0 +1,18 @@
+-- establish subset of client (with no cases) which have NO documents
+SELECT cl.*
+INTO deleted_cases_sw6081.clients_selection
+FROM deleted_cases_sw6081.clients_nocases_no_documents cl
+ORDER BY cl.id
+LIMIT :runLimit
+OFFSET :runOffset;
+
+-- new run
+INSERT INTO deleted_cases_sw6081.run (id, notes, selections_made_at, clients_affected)
+VALUES (
+    :runId,
+    CONCAT(:'notePrefix', ' - LIMIT: ', :runLimit, ', OFFSET: ', :runOffset),
+    CURRENT_TIMESTAMP(0),
+    (SELECT COUNT(1) FROM deleted_cases_sw6081.clients_selection)
+);
+
+SELECT * FROM deleted_cases_sw6081.run;

--- a/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/setup_CAUTION_run_once.sql
+++ b/migration_steps/validation/post_migration_fixes/app/pmf_sql_statements/27_pmf_skeletoncases_sw6081/setup_CAUTION_run_once.sql
@@ -1,0 +1,426 @@
+-- delete this
+
+SELECT COUNT(1) FROM (
+
+) t1;
+
+SELECT * FROM deleted_cases_sw6081.deleted_timeline_event_audit ORDER BY id DESC LIMIT 10;
+
+WITH latest_timeline AS(
+    SELECT
+    person_id,
+    MAX(timestamp) as latest
+    FROM deleted_cases_sw6081.deleted_person_timeline dpt
+    INNER JOIN deleted_cases_sw6081.deleted_timeline_event_audit tea
+        ON tea.id = dpt.timelineevent_id
+    WHERE dpt.delete_run_id > 33
+    -- AND timestamp > '2022-08-08 00:00:00'
+    GROUP BY person_id
+) --229
+SELECT
+    cl.id,
+    cl.caserecnumber,
+    cl.clientsource,
+    cl.caseactorgroup,
+    a.email,
+    cl.statusdate,
+    cl.createddate,
+    cl.updateddate,
+    cl.latest_activity client_latest_activity,
+    cl.delete_run_id
+    -- dtea.timestamp AS timeline_event_timestamp,
+    -- timeline_assignees.email AS timeline_event_email,
+    -- dtea.eventtype timeline_event_type,
+    -- dtea.event
+FROM deleted_cases_sw6081.run_clients cl
+INNER JOIN assignees a
+    ON cl.supervisioncaseowner_id = a.id
+-- LEFT JOIN latest_timeline lt
+--     ON lt.person_id = cl.id
+-- LEFT JOIN deleted_cases_sw6081.deleted_person_timeline dpt
+--     ON dpt.person_id = cl.id
+-- LEFT JOIN deleted_cases_sw6081.deleted_timeline_event_audit dtea
+--     ON dtea.id = dpt.timelineevent_id
+-- LEFT JOIN assignees timeline_assignees
+--     ON dtea.user_id = timeline_assignees.id
+WHERE cl.latest_activity > '2022-08-08 00:00:00'
+AND cl.delete_run_id > 33 -- new runs Nov 9th 34,35,36,37,38 @ 2000 each
+ORDER BY cl.id, latest_activity DESC;
+
+-- query missing client
+SELECT
+    p.id,
+    dpc.id
+    dpca.* 
+    FROM 
+
+
+-- end delete this
+
+
+
+
+DROP SCHEMA IF EXISTS deleted_cases_sw6081 CASCADE;
+CREATE SCHEMA IF NOT EXISTS deleted_cases_sw6081;
+
+CREATE TABLE deleted_cases_sw6081.run (
+    id int PRIMARY KEY,
+    notes varchar(255),
+    selections_made_at timestamp,
+    deleted_at timestamp,
+    clients_affected int
+);
+CREATE SEQUENCE deleted_cases_sw6081.deleterun_id_seq start 1 increment 1;
+
+CREATE TABLE deleted_cases_sw6081.run_clients (
+    id int NOT NULL,
+    caserecnumber varchar(255),
+    clientsource varchar(255),
+    caseactorgroup varchar(255),
+    supervisioncaseowner_id int,
+    statusdate date,
+    createddate timestamp,
+    updateddate timestamp,
+    latest_timestamp timestamp,
+    latest_activity date,
+    delete_run_id int
+);
+ALTER TABLE deleted_cases_sw6081.run_clients
+    ADD CONSTRAINT fk_deleterunid
+    foreign key (delete_run_id) references deleted_cases_sw6081.run
+ON DELETE CASCADE;
+
+-- MAIN SELECT - ALL CLIENTS WITH NO CASES
+DROP TABLE IF EXISTS deleted_cases_sw6081.clients_nocases;
+SELECT DISTINCT
+    p.id,
+    p.caserecnumber,
+    p.clientsource,
+    p.caseactorgroup,
+    p.supervisioncaseowner_id,
+    p.statusdate,
+    p.createddate,
+    p.updateddate
+INTO deleted_cases_sw6081.clients_nocases
+FROM persons p
+LEFT JOIN cases c ON c.client_id = p.id
+WHERE p.type = 'actor_client'-- supervision clients only
+AND c.id IS NULL -- has no orders
+ORDER BY p.id ASC;
+CREATE INDEX idx_sw6081_clients_nocases_id ON deleted_cases_sw6081.clients_nocases USING btree (id);
+
+DROP TABLE IF EXISTS deleted_cases_sw6081.clients_nocases_no_documents;
+SELECT *
+INTO deleted_cases_sw6081.clients_nocases_no_documents
+FROM deleted_cases_sw6081.clients_nocases cl_nocases
+LEFT JOIN person_document pd ON pd.person_id = cl_nocases.id
+WHERE pd.document_id IS NULL
+ORDER BY cl_nocases.id ASC;
+CREATE INDEX idx_sw6081_clients_nocases_nodocs_id ON deleted_cases_sw6081.clients_nocases_no_documents USING btree (id);
+
+DROP TABLE IF EXISTS deleted_cases_sw6081.clients_nocases_with_documents;
+SELECT cl.*
+INTO deleted_cases_sw6081.clients_nocases_with_documents
+FROM deleted_cases_sw6081.clients_nocases cl
+INNER JOIN (
+    SELECT DISTINCT cl_nocases.id
+    FROM deleted_cases_sw6081.clients_nocases cl_nocases
+    LEFT JOIN person_document pd
+        ON pd.person_id = cl_nocases.id
+    WHERE pd.document_id IS NOT NULL
+) t1
+    ON t1.id = cl.id
+ORDER BY cl.id ASC;
+CREATE INDEX idx_sw6081_clients_nocases_withdocs_id ON deleted_cases_sw6081.clients_nocases_with_documents USING btree (id);
+
+CREATE TABLE deleted_cases_sw6081.results (
+    delete_table varchar(255)
+);
+INSERT INTO deleted_cases_sw6081.results VALUES
+('addresses'),
+('annual_report_logs'),
+('annual_report_letter_status'),
+('annual_report_type_assignments'),
+('annual_report_lodging_details'),
+('death_notifications'),
+('finance_person'),
+('finance_invoice'),
+('finance_order'),
+('finance_remission_exemption'),
+('finance_invoice_fee_range'),
+('finance_ledger'),
+('finance_ledger_allocation'),
+('person_note'),
+('notes'),
+('person_personreference'),
+('person_references'),
+('person_research_preferences'),
+('person_task'),
+('tasks'),
+('person_timeline'),
+('timeline_event'),
+('person_warning'),
+('warnings'),
+('phonenumbers'),
+('supervision_notes'),
+('visits'),
+('cases'),
+('person_document'),
+('document_pages'),
+('document_secondaryrecipient'),
+('documents'),
+('persons_contacts'),
+('persons_deputies'),
+('persons_clients_audit');
+
+-- tables to hold audit information
+
+-- addresses
+CREATE TABLE deleted_cases_sw6081.deleted_addresses(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_addresses_audit FROM addresses a WHERE False;
+
+-- annual_report_logs
+CREATE TABLE deleted_cases_sw6081.deleted_annual_report_logs(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_annual_report_logs_audit FROM annual_report_logs WHERE False;
+
+-- annual_report_letter_status
+CREATE TABLE deleted_cases_sw6081.deleted_annual_report_letter_status(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_annual_report_letter_status_audit FROM annual_report_letter_status WHERE False;
+
+-- annual_report_type_assignments
+CREATE TABLE deleted_cases_sw6081.deleted_annual_report_type_assignments(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_annual_report_type_assignments_audit FROM annual_report_type_assignments WHERE False;
+
+-- annual_report_lodging_details
+CREATE TABLE deleted_cases_sw6081.deleted_annual_report_lodging_details(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_annual_report_lodging_details_audit FROM annual_report_lodging_details WHERE False;
+
+-- death_notifications
+CREATE TABLE deleted_cases_sw6081.deleted_death_notifications(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_death_notifications_audit FROM death_notifications WHERE False;
+
+-- finance_person (supervision schema)
+CREATE TABLE deleted_cases_sw6081.deleted_finance_person(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_person_audit FROM supervision.finance_person WHERE False;
+
+-- finance_invoice (supervision schema)
+CREATE TABLE deleted_cases_sw6081.deleted_finance_invoice(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_invoice_audit FROM supervision.finance_invoice WHERE False;
+
+-- finance_order (supervision schema)
+CREATE TABLE deleted_cases_sw6081.deleted_finance_order(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_order_audit FROM supervision.finance_order WHERE False;
+
+-- finance_remission_exemption (supervision schema)
+CREATE TABLE deleted_cases_sw6081.deleted_finance_remission_exemption(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_remission_exemption_audit FROM supervision.finance_remission_exemption WHERE False;
+
+-- finance_invoice_fee_range
+CREATE TABLE deleted_cases_sw6081.deleted_finance_invoice_fee_range(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_invoice_fee_range_audit FROM finance_invoice_fee_range WHERE False;
+
+-- finance_ledger
+CREATE TABLE deleted_cases_sw6081.deleted_finance_ledger(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_ledger_audit FROM finance_ledger WHERE False;
+
+-- finance_ledger_allocation
+CREATE TABLE deleted_cases_sw6081.deleted_finance_ledger_allocation(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_finance_ledger_allocation_audit FROM finance_ledger_allocation WHERE False;
+
+-- person_note
+CREATE TABLE deleted_cases_sw6081.deleted_person_note(
+    person_id int NOT NULL,
+    note_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_note_audit FROM person_note WHERE False;
+
+-- notes
+CREATE TABLE deleted_cases_sw6081.deleted_notes(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_notes_audit FROM notes WHERE False;
+
+-- person_personreference
+CREATE TABLE deleted_cases_sw6081.deleted_person_personreference(
+    person_id int NOT NULL,
+    person_reference_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_personreference_audit FROM person_personreference WHERE False;
+
+-- person_references
+CREATE TABLE deleted_cases_sw6081.deleted_person_references(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_references_audit FROM person_references WHERE False;
+
+-- person_research_preferences
+CREATE TABLE deleted_cases_sw6081.deleted_person_research_preferences(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_research_preferences_audit FROM person_research_preferences WHERE False;
+
+-- person_task
+CREATE TABLE deleted_cases_sw6081.deleted_person_task(
+    person_id int NOT NULL,
+    task_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_task_audit FROM person_task WHERE False;
+
+-- tasks
+CREATE TABLE deleted_cases_sw6081.deleted_tasks(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_tasks_audit FROM tasks WHERE False;
+
+-- person_timeline
+CREATE TABLE deleted_cases_sw6081.deleted_person_timeline(
+    id int NOT NULL,
+    person_id int NOT NULL,
+    timelineevent_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_timeline_audit FROM person_timeline WHERE False;
+
+-- timeline_event
+CREATE TABLE deleted_cases_sw6081.deleted_timeline_event(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_timeline_event_audit FROM timeline_event WHERE False;
+
+-- person_warning
+CREATE TABLE deleted_cases_sw6081.deleted_person_warning(
+    person_id int NOT NULL,
+    warning_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_warning_audit FROM person_warning WHERE False;
+
+-- warnings
+CREATE TABLE deleted_cases_sw6081.deleted_warnings(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_warnings_audit FROM warnings WHERE False;
+
+-- phonenumbers
+CREATE TABLE deleted_cases_sw6081.deleted_phonenumbers(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_phonenumbers_audit FROM phonenumbers WHERE False;
+
+-- supervision_notes
+CREATE TABLE deleted_cases_sw6081.deleted_supervision_notes(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_supervision_notes_audit FROM supervision_notes WHERE False;
+
+-- visits
+CREATE TABLE deleted_cases_sw6081.deleted_visits(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_visits_audit FROM visits WHERE False;
+
+-- cases (should be zero at all times)
+CREATE TABLE deleted_cases_sw6081.deleted_cases(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_cases_audit FROM cases WHERE False;
+
+-- person_document
+CREATE TABLE deleted_cases_sw6081.deleted_person_document(
+    person_id int NOT NULL,
+    document_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_person_document_audit FROM person_document WHERE False;
+
+-- document_pages
+CREATE TABLE deleted_cases_sw6081.deleted_document_pages(
+    id int NOT NULL,
+    document_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_document_pages_audit FROM document_pages WHERE False;
+
+-- document_secondaryrecipient
+CREATE TABLE deleted_cases_sw6081.deleted_document_secondaryrecipient(
+    document_id int NOT NULL,
+    person_id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_document_secondaryrecipient_audit FROM document_secondaryrecipient WHERE False;
+
+-- document
+CREATE TABLE deleted_cases_sw6081.deleted_documents(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_documents_audit FROM documents WHERE False;
+
+-- persons (contacts)
+CREATE TABLE deleted_cases_sw6081.deleted_persons_contacts(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_persons_contacts_audit FROM persons WHERE False;
+
+-- persons (deputies)
+CREATE TABLE deleted_cases_sw6081.deleted_persons_deputies(
+    id int NOT NULL,
+    delete_run_id int NOT NULL
+);
+SELECT * INTO deleted_cases_sw6081.deleted_persons_deputies_audit FROM persons WHERE False;
+
+-- persons (clients)
+SELECT * INTO deleted_cases_sw6081.deleted_persons_clients_audit FROM persons WHERE False;


### PR DESCRIPTION
Covers sw6081 & 6083

## Purpose

As per the ticket. Mass deletions of 'stub data' which is mostly data that was created at the time of the Livelink migration in 2019. The Stub cases are preventing the proper creation of clients as part of the normal ingest and specifically preventing the creation of an 'allocate' task, which meant cases were going unnoticed.

## Approach

Approached this as cautiously as we approached the migration. It is deleting 118k rows from persons table and close to a million documents after all.

Leveraged the same approach - in a new schema dedicated to the pmf, make a direct copy of everything deleted with two tables for each entity, one for the IDs and one '_audit' table containing the data itself.

I also wrote helper scripts 'prepare' and 'run' which allow us to stop and assess the data proposed to be deleted and run each run phase granuarly..

## Learning

Learned/refreshed a bunch about bash

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have done an adhoc run against preprod (only needed for high complexity PRs)
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
